### PR TITLE
#1: setup project structure and monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.egg-info/
+
+# Node
+node_modules/
+.next/
+out/
+dist/
+.turbo/
+npm-debug.log*
+
+# Env
+.env
+.env.local
+.env.*.local
+
+# OS / IDE
+.DS_Store
+.idea/
+.vscode/
+
+# Railway
+.railway/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+## Branching
+
+- Base new work from `dev`:
+
+  `git checkout dev && git pull origin dev && git checkout -b feature/issue-N-short-slug`
+
+## Commits
+
+- Message format: `#N: short description` (issue number from GitHub)
+
+## Pull requests
+
+- Title: `#N: short description`
+- Body: include `Closes #N` so merging auto-closes the issue
+- Merge feature PRs into **`dev`** first; **`main`** for releases (`dev` → `main`)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# diet-ai-app
-Bootstrap on `main` before issue #1 merges.
+# Diet AI App (monorepo)
+
+Private monorepo for the Diet & Nutrition AI Chat App.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `frontend/` | Next.js 14 (App Router) UI — wired in issues 7+ |
+| `backend/` | FastAPI + LangChain — wired in issues 2+ |
+| `.github/workflows/` | CI in issues 13–14 |
+
+Placeholder `README.md` files exist under `frontend/` and `backend/` until those folders hold real apps.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,3 @@
+# Backend
+
+Placeholder for the FastAPI backend (issue #2 onward).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+Placeholder for the Next.js app (issue 7 onward).


### PR DESCRIPTION
## Summary
Adds the monorepo skeleton: `frontend/`, `backend/`, `.github/workflows/`, root docs, `.gitignore`, and `CONTRIBUTING.md`.

**Does not add application code yet** — only structure for review and later issues.

Closes #1