### PR TITLE
#2: FastAPI boilerplate + GET /health endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,14 @@
 # Backend
 
-Placeholder for the FastAPI backend (issue #2 onward).
+FastAPI service (minimal); see **issue #2** for `/health`.
+
+## Run locally
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Then open `GET http://127.0.0.1:8000/health` — expect `{ "status": "ok" }`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,11 @@
+"""FastAPI backend (issue #2: health check)."""
+
+from fastapi import FastAPI
+
+app = FastAPI(title="Diet Nutrition AI API", version="1.0.0")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Liveness/readiness probe for Railway and localhost."""
+    return {"status": "ok"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.109.2
+uvicorn[standard]==0.27.1


### PR DESCRIPTION
## What this does

- Adds `backend/main.py` with a **FastAPI** app and `GET /health` returning `{"status": "ok"}`.
- Adds `backend/requirements.txt` with `fastapi` and `uvicorn[standard]`.
- Updates `backend/README.md` with local run instructions (`uvicorn main:app`).

**Out of scope** (later issues): AES, chat, LangChain, CI, Railway.

Closes #2