### PR TITLE
#3: Backend AES decryption (CryptoJS-compatible)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+# Must match NEXT_PUBLIC_ENCRYPTION_SECRET on the frontend (passphrase format like CryptoJS)
+ENCRYPTION_SECRET=change-me-same-as-frontend-passphrase

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,10 @@
 # Backend
 
-FastAPI service (minimal); see **issue #2** for `/health`.
+FastAPI service: `GET /health` (issue **#2**).
+
+## Encryption (issue **#3**)
+
+Anthropic keys are AES-encrypted in the browser (`crypto-js`). The backend decrypts payloads with **`decrypt_cryptojs_openssl` in `crypto_util.py`**, using the passphrase from env **`ENCRYPTION_SECRET`**. It **must match** **`NEXT_PUBLIC_ENCRYPTION_SECRET`** on the frontend (`crypto-js`).
 
 ## Run locally
 
@@ -12,3 +16,9 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 ```
 
 Then open `GET http://127.0.0.1:8000/health` — expect `{ "status": "ok" }`.
+
+## Tests (crypto utilities)
+
+```bash
+pytest tests/
+```

--- a/backend/crypto_util.py
+++ b/backend/crypto_util.py
@@ -1,0 +1,49 @@
+"""Decrypt CryptoJS/OpenSSL salted AES ciphertext (AES-256-CBC + MD5 EVP_BytesToKey).
+
+Matches frontend: ``CryptoJS.AES.encrypt(plain, passphrase).toString()``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad, unpad
+
+
+def _evp_bytes_to_key(password: bytes, salt: bytes, key_len: int, iv_len: int) -> tuple[bytes, bytes]:
+    """OpenSSL EVP_BytesToKey with MD5 (CryptoJS default when using a passphrase string)."""
+    derived = b""
+    prev = b""
+    while len(derived) < key_len + iv_len:
+        prev = hashlib.md5(prev + password + salt).digest()
+        derived += prev
+    return derived[:key_len], derived[key_len : key_len + iv_len]
+
+
+def decrypt_cryptojs_openssl(ciphertext_b64: str, passphrase: str) -> str:
+    """Decrypt string produced by ``CryptoJS.AES.encrypt(plain, passphrase).toString()``."""
+    raw = base64.b64decode(ciphertext_b64.strip())
+    if not raw.startswith(b"Salted__"):
+        raise ValueError("Invalid ciphertext: missing OpenSSL salt header (Salted__)")
+    salt = raw[8:16]
+    body = raw[16:]
+    key, iv = _evp_bytes_to_key(passphrase.encode("utf-8"), salt, 32, 16)
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    decrypted = cipher.decrypt(body)
+    try:
+        return unpad(decrypted, AES.block_size).decode("utf-8")
+    except ValueError as exc:
+        raise ValueError("Invalid ciphertext padding") from exc
+
+
+def encrypt_cryptojs_openssl(plaintext: str, passphrase: str) -> str:
+    """Encrypt compatibly with CryptoJS (same format as openssl ``enc -aes-256-cbc`` salted)."""
+
+    salt = os.urandom(8)
+    key, iv = _evp_bytes_to_key(passphrase.encode("utf-8"), salt, 32, 16)
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    ct = cipher.encrypt(pad(plaintext.encode("utf-8"), AES.block_size))
+    return base64.b64encode(b"Salted__" + salt + ct).decode("ascii")

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,6 @@
 fastapi==0.109.2
 uvicorn[standard]==0.27.1
+pycryptodome==3.20.0
+
+# dev/tests
+pytest>=8.3

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Environment for tests."""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("ENCRYPTION_SECRET", "test-shared-secret-for-pytest-only!!")
+

--- a/backend/tests/test_crypto_util.py
+++ b/backend/tests/test_crypto_util.py
@@ -1,0 +1,26 @@
+"""Tests for CryptoJS-compatible encrypt/decrypt."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from crypto_util import decrypt_cryptojs_openssl, encrypt_cryptojs_openssl
+
+SECRET = "test-shared-secret-for-pytest-only!!"
+
+
+def test_roundtrip_decrypt_matches_plaintext() -> None:
+    plain = "sk-ant-api-example-key-not-real"
+    enc = encrypt_cryptojs_openssl(plain, SECRET)
+    assert len(enc) > 0
+    raw = decrypt_cryptojs_openssl(enc, SECRET)
+    assert raw == plain
+
+
+def test_missing_salted_header_raises() -> None:
+    # Valid base64 of bytes that do not start with Salted__
+    bogus = base64.b64encode(b"nope-no-header").decode("ascii")
+    with pytest.raises(ValueError, match="Salted"):
+        decrypt_cryptojs_openssl(bogus, SECRET)


### PR DESCRIPTION
## Summary

Implements **`decrypt_cryptojs_openssl`** (+ matching **`encrypt_cryptojs_openssl`** for tests) in [`backend/crypto_util.py`](backend/crypto_util.py): OpenSSL salted **`Salted__`** format, AES-256-CBC, MD5 EVP key derivation — same as `CryptoJS.AES.encrypt(..., passphrase)` on the client.

- Adds **`pycryptodome`** to [`backend/requirements.txt`](backend/requirements.txt)
- Documents `ENCRYPTION_SECRET` in [`backend/.env.example`](backend/.env.example)
- Adds [`pytest`](backend/pytest.ini) + [`tests/test_crypto_util.py`](backend/tests/test_crypto_util.py) (round-trip + invalid header)
- Updates [`backend/README.md`](backend/README.md)

**Next issue:** wire this into FastAPI request bodies + LangChain (issue #4).

Closes #3