### PR TITLE
#4: LangChain + LangGraph Claude chat endpoint (POST /api/chat)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,2 +1,5 @@
 # Must match NEXT_PUBLIC_ENCRYPTION_SECRET on the frontend (passphrase format like CryptoJS)
 ENCRYPTION_SECRET=change-me-same-as-frontend-passphrase
+
+# Shared secret; request header X-App-Password must match
+APP_PASSWORD=change-me-app-gate

--- a/backend/README.md
+++ b/backend/README.md
@@ -17,7 +17,24 @@ uvicorn main:app --reload --host 0.0.0.0 --port 8000
 
 Then open `GET http://127.0.0.1:8000/health` — expect `{ "status": "ok" }`.
 
-## Tests (crypto utilities)
+Copy `.env.example` to `.env` and set `APP_PASSWORD` and `ENCRYPTION_SECRET`.
+
+## Chat API (issue **#4**)
+
+`POST /api/chat` JSON body:
+
+```json
+{
+  "encrypted_api_key": "<CryptoJS ciphertext>",
+  "message": "user text",
+  "conversation_id": null
+}
+```
+
+Headers: `X-App-Password: <APP_PASSWORD>`  
+Response: `{ "reply": "...", "conversation_id": "<uuid>" }` (multi-turn memory in issue **#6**).
+
+## Tests
 
 ```bash
 pytest tests/

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,11 +1,69 @@
-"""FastAPI backend (issue #2: health check)."""
+"""FastAPI backend: health + nutrition chat (issue #4)."""
 
-from fastapi import FastAPI
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from crypto_util import decrypt_cryptojs_openssl
+from nutrition_graph import run_nutrition_chat
+
+
+class Settings(BaseSettings):
+    app_password: str
+    encryption_secret: str
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+
+settings = Settings()
 
 app = FastAPI(title="Diet Nutrition AI API", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class ChatBody(BaseModel):
+    encrypted_api_key: str
+    message: str
+    conversation_id: str | None = None  # multi-turn memory wired in issue #6
+
+
+def verify_app_password(x_app_password: str | None = Header(None, alias="X-App-Password")) -> None:
+    if x_app_password is None:
+        raise HTTPException(status_code=403, detail="Missing X-App-Password header")
+    if x_app_password != settings.app_password:
+        raise HTTPException(status_code=403, detail="Invalid app password")
+
+
+def decrypt_user_key(enc: str) -> str:
+    try:
+        return decrypt_cryptojs_openssl(enc.strip(), settings.encryption_secret)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Could not decrypt API key: {exc}") from exc
+
+
+DependsPassword = Depends(verify_app_password)
 
 
 @app.get("/health")
 async def health() -> dict[str, str]:
-    """Liveness/readiness probe for Railway and localhost."""
     return {"status": "ok"}
+
+
+@app.post("/api/chat")
+async def api_chat(body: ChatBody, _: None = DependsPassword) -> dict[str, Any]:
+    api_key_plain = decrypt_user_key(body.encrypted_api_key)
+    reply, conv_id = run_nutrition_chat(api_key_plain, body.message)
+    return {"reply": reply, "conversation_id": conv_id}
+

--- a/backend/nutrition_graph.py
+++ b/backend/nutrition_graph.py
@@ -1,0 +1,56 @@
+"""LangGraph agent: Claude + nutrition system prompt (single-turn per request for issue #4)."""
+
+from __future__ import annotations
+
+import uuid
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+SYSTEM_PROMPT = """You are a professional nutritionist and diet coach. Help users with meal planning,
+calorie tracking, macro analysis, food choices, and healthy eating habits.
+When analyzing food images, provide detailed nutritional estimates."""
+
+MODEL_NAME = "claude-sonnet-4-20250514"
+
+_graph = None
+
+
+def _call_model(state: MessagesState, config: RunnableConfig) -> dict:
+    api_key = (config.get("configurable") or {}).get("anthropic_api_key")
+    if not api_key:
+        raise ValueError("Missing anthropic_api_key in runnable config")
+
+    llm = ChatAnthropic(
+        anthropic_api_key=api_key,
+        model=MODEL_NAME,
+        temperature=0.4,
+        max_tokens=4096,
+    )
+    msgs = [SystemMessage(content=SYSTEM_PROMPT), *state["messages"]]
+    ai: AIMessage = llm.invoke(msgs)
+    return {"messages": [ai]}
+
+
+def get_graph():
+    global _graph
+    if _graph is None:
+        g = StateGraph(MessagesState)
+        g.add_node("agent", _call_model)
+        g.add_edge(START, "agent")
+        g.add_edge("agent", END)
+        _graph = g.compile()
+    return _graph
+
+
+def run_nutrition_chat(decrypted_api_key: str, user_message: str) -> tuple[str, str]:
+    """Return (assistant_text, conversation_id). Memory per session lands in issue #6."""
+    graph = get_graph()
+    cfg: RunnableConfig = {"configurable": {"anthropic_api_key": decrypted_api_key}}
+    out = graph.invoke({"messages": [HumanMessage(content=user_message)]}, cfg)
+    last = out["messages"][-1]
+    body = getattr(last, "content", "")
+    text = body if isinstance(body, str) else str(body)
+    return text, str(uuid.uuid4())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,11 @@
 fastapi==0.109.2
 uvicorn[standard]==0.27.1
 pycryptodome==3.20.0
+pydantic-settings==2.1.0
+langchain-core>=0.3.5
+langchain-anthropic>=0.3.0
+langgraph>=0.2.55
+httpx>=0.27.0,<0.28
 
 # dev/tests
 pytest>=8.3

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,4 +5,4 @@ from __future__ import annotations
 import os
 
 os.environ.setdefault("ENCRYPTION_SECRET", "test-shared-secret-for-pytest-only!!")
-
+os.environ.setdefault("APP_PASSWORD", "test-app-password")

--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -1,0 +1,39 @@
+"""Integration tests for POST /api/chat (mocked LLM)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage
+
+from crypto_util import encrypt_cryptojs_openssl
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    def fake_invoke(self, messages, *args, **kwargs):  # noqa: ANN001
+        return AIMessage(content="Mock nutrition reply about protein.")
+
+    monkeypatch.setattr("langchain_anthropic.ChatAnthropic.invoke", fake_invoke)
+    from main import app
+
+    return TestClient(app)
+
+
+def test_chat_missing_app_password(client: TestClient) -> None:
+    enc = encrypt_cryptojs_openssl("sk-test", "test-shared-secret-for-pytest-only!!")
+    r = client.post("/api/chat", json={"encrypted_api_key": enc, "message": "Hi"})
+    assert r.status_code == 403
+
+
+def test_chat_success(client: TestClient) -> None:
+    enc = encrypt_cryptojs_openssl("sk-test", "test-shared-secret-for-pytest-only!!")
+    r = client.post(
+        "/api/chat",
+        json={"encrypted_api_key": enc, "message": "How much protein per day?"},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["reply"]
+    assert "conversation_id" in data


### PR DESCRIPTION
## Summary

- **nutrition_graph.py:** LangGraph StateGraph + MessagesState, ChatAnthropic **claude-sonnet-4-20250514**, nutrition system prompt.
- **main.py:** Settings (APP_PASSWORD, ENCRYPTION_SECRET), CORS, POST **/api/chat** with X-App-Password and encrypted_api_key.
- **Tests:** test_chat_api.py (mocked LLM).

Multi-turn memory / reset in issue **#6**. Image endpoint in issue **#5**.

Closes #4