### PR TITLE
#5: Image upload + Claude vision (POST /api/chat/image)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -34,6 +34,19 @@ Copy `.env.example` to `.env` and set `APP_PASSWORD` and `ENCRYPTION_SECRET`.
 Headers: `X-App-Password: <APP_PASSWORD>`  
 Response: `{ "reply": "...", "conversation_id": "<uuid>" }` (multi-turn memory in issue **#6**).
 
+## Image upload (issue **#5**)
+
+`POST /api/chat/image` — multipart form:
+
+| Field | Type | Notes |
+|-------|------|--------|
+| `encrypted_api_key` | string | CryptoJS ciphertext (same as text chat) |
+| `conversation_id` | string | optional placeholder (issue **#6**) |
+| `message` | string | optional caption |
+| `image` | file | image/jpeg, png, … |
+
+Same header **`X-App-Password`**. Response shape: `{ "reply", "conversation_id" }`.
+
 ## Tests
 
 ```bash

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,16 +1,16 @@
-"""FastAPI backend: health + nutrition chat (issue #4)."""
+"""FastAPI backend: health, text chat, image chat."""
 
 from __future__ import annotations
 
 from typing import Any
 
-from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from crypto_util import decrypt_cryptojs_openssl
-from nutrition_graph import run_nutrition_chat
+from nutrition_graph import run_nutrition_chat, run_nutrition_image_chat
 
 
 class Settings(BaseSettings):
@@ -65,5 +65,23 @@ async def health() -> dict[str, str]:
 async def api_chat(body: ChatBody, _: None = DependsPassword) -> dict[str, Any]:
     api_key_plain = decrypt_user_key(body.encrypted_api_key)
     reply, conv_id = run_nutrition_chat(api_key_plain, body.message)
+    return {"reply": reply, "conversation_id": conv_id}
+
+
+@app.post("/api/chat/image")
+async def api_chat_image(
+    _: None = DependsPassword,
+    encrypted_api_key: str = Form(...),
+    conversation_id: str = Form(""),
+    message: str = Form(""),
+    image: UploadFile = File(...),
+) -> dict[str, Any]:
+    api_key_plain = decrypt_user_key(encrypted_api_key)
+    _ = conversation_id  # forwarded with multi-turn memory in issue #6
+    raw = await image.read()
+    if not raw:
+        raise HTTPException(status_code=400, detail="Empty image upload")
+    media = image.content_type or "application/octet-stream"
+    reply, conv_id = run_nutrition_image_chat(api_key_plain, media, raw, message or None)
     return {"reply": reply, "conversation_id": conv_id}
 

--- a/backend/nutrition_graph.py
+++ b/backend/nutrition_graph.py
@@ -1,7 +1,8 @@
-"""LangGraph agent: Claude + nutrition system prompt (single-turn per request for issue #4)."""
+"""LangGraph agent: Claude + nutrition system prompt."""
 
 from __future__ import annotations
 
+import base64
 import uuid
 
 from langchain_anthropic import ChatAnthropic
@@ -45,12 +46,37 @@ def get_graph():
     return _graph
 
 
+def _assistant_text_from_result(out: dict) -> str:
+    last = out["messages"][-1]
+    body = getattr(last, "content", "")
+    return body if isinstance(body, str) else str(body)
+
+
 def run_nutrition_chat(decrypted_api_key: str, user_message: str) -> tuple[str, str]:
     """Return (assistant_text, conversation_id). Memory per session lands in issue #6."""
     graph = get_graph()
     cfg: RunnableConfig = {"configurable": {"anthropic_api_key": decrypted_api_key}}
     out = graph.invoke({"messages": [HumanMessage(content=user_message)]}, cfg)
-    last = out["messages"][-1]
-    body = getattr(last, "content", "")
-    text = body if isinstance(body, str) else str(body)
-    return text, str(uuid.uuid4())
+    return _assistant_text_from_result(out), str(uuid.uuid4())
+
+
+def run_nutrition_image_chat(
+    decrypted_api_key: str,
+    media_type: str,
+    image_bytes: bytes,
+    user_caption: str | None,
+) -> tuple[str, str]:
+    """Vision: food image + optional caption. Same graph; multimodal HumanMessage."""
+    caption = (user_caption or "").strip()
+    if not caption:
+        caption = "Describe this food and estimate nutrition (calories and macros)."
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    media = media_type.strip() if media_type else "application/octet-stream"
+    content = [
+        {"type": "text", "text": caption},
+        {"type": "image_url", "image_url": {"url": f"data:{media};base64,{b64}"}},
+    ]
+    graph = get_graph()
+    cfg: RunnableConfig = {"configurable": {"anthropic_api_key": decrypted_api_key}}
+    out = graph.invoke({"messages": [HumanMessage(content=content)]}, cfg)
+    return _assistant_text_from_result(out), str(uuid.uuid4())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi==0.109.2
 uvicorn[standard]==0.27.1
+python-multipart==0.0.9
 pycryptodome==3.20.0
 pydantic-settings==2.1.0
 langchain-core>=0.3.5

--- a/backend/tests/test_image_api.py
+++ b/backend/tests/test_image_api.py
@@ -1,0 +1,54 @@
+"""POST /api/chat/image multipart tests."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage
+
+from crypto_util import encrypt_cryptojs_openssl
+
+PNG_1X1_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    def fake_invoke(self, messages, *args, **kwargs):  # noqa: ANN001
+        return AIMessage(content="Vision: mock macros for this snack.")
+
+    monkeypatch.setattr("langchain_anthropic.ChatAnthropic.invoke", fake_invoke)
+    from main import app
+
+    return TestClient(app)
+
+
+def test_chat_image_requires_password(client: TestClient) -> None:
+    enc = encrypt_cryptojs_openssl("sk-test", "test-shared-secret-for-pytest-only!!")
+    r = client.post(
+        "/api/chat/image",
+        data={"encrypted_api_key": enc, "message": "how many calories?"},
+        files={"image": ("tiny.png", PNG_1X1_BYTES, "image/png")},
+    )
+    assert r.status_code == 403
+
+
+def test_chat_image_success(client: TestClient) -> None:
+    enc = encrypt_cryptojs_openssl("sk-test", "test-shared-secret-for-pytest-only!!")
+    r = client.post(
+        "/api/chat/image",
+        data={
+            "encrypted_api_key": enc,
+            "message": "Rough calories?",
+            "conversation_id": "",
+        },
+        files={"image": ("tiny.png", PNG_1X1_BYTES, "image/png")},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("reply")
+    assert data.get("conversation_id")


### PR DESCRIPTION
## Summary

- **POST `/api/chat/image`:** multipart form with `encrypted_api_key`, optional `conversation_id`, optional `message`, file `image`.
- **nutrition_graph:** `run_nutrition_image_chat` multimodal HumanMessage.
- **python-multipart** dependency.
- **Tests:** test_image_api.py

Closes #5