### PR TITLE
#6: LangGraph multi-turn conversation memory + /api/chat/reset

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -32,7 +32,23 @@ Copy `.env.example` to `.env` and set `APP_PASSWORD` and `ENCRYPTION_SECRET`.
 ```
 
 Headers: `X-App-Password: <APP_PASSWORD>`  
-Response: `{ "reply": "...", "conversation_id": "<uuid>" }` (multi-turn memory in issue **#6**).
+Response: `{ "reply": "...", "conversation_id": "<uuid>" }`.
+
+Send the returned **`conversation_id`** on later turns so the assistant keeps thread context (stored **in-memory** on the server).
+
+## Reset conversation (issue **#6**)
+
+`POST /api/chat/reset`:
+
+```json
+{
+  "encrypted_api_key": "<CryptoJS ciphertext>",
+  "conversation_id": "<id to clear>"
+}
+```
+
+Headers: `X-App-Password`  
+Response: `{ "ok": true, "conversation_id": "..." }`
 
 ## Image upload (issue **#5**)
 
@@ -41,7 +57,7 @@ Response: `{ "reply": "...", "conversation_id": "<uuid>" }` (multi-turn memory i
 | Field | Type | Notes |
 |-------|------|--------|
 | `encrypted_api_key` | string | CryptoJS ciphertext (same as text chat) |
-| `conversation_id` | string | optional placeholder (issue **#6**) |
+| `conversation_id` | string | optional; omit or send server id to stay in-thread |
 | `message` | string | optional caption |
 | `image` | file | image/jpeg, png, … |
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from crypto_util import decrypt_cryptojs_openssl
-from nutrition_graph import run_nutrition_chat, run_nutrition_image_chat
+from nutrition_graph import reset_conversation, run_nutrition_chat, run_nutrition_image_chat
 
 
 class Settings(BaseSettings):
@@ -36,7 +36,12 @@ app.add_middleware(
 class ChatBody(BaseModel):
     encrypted_api_key: str
     message: str
-    conversation_id: str | None = None  # multi-turn memory wired in issue #6
+    conversation_id: str | None = None
+
+
+class ResetBody(BaseModel):
+    encrypted_api_key: str
+    conversation_id: str
 
 
 def verify_app_password(x_app_password: str | None = Header(None, alias="X-App-Password")) -> None:
@@ -64,7 +69,7 @@ async def health() -> dict[str, str]:
 @app.post("/api/chat")
 async def api_chat(body: ChatBody, _: None = DependsPassword) -> dict[str, Any]:
     api_key_plain = decrypt_user_key(body.encrypted_api_key)
-    reply, conv_id = run_nutrition_chat(api_key_plain, body.message)
+    reply, conv_id = run_nutrition_chat(api_key_plain, body.message, body.conversation_id)
     return {"reply": reply, "conversation_id": conv_id}
 
 
@@ -77,11 +82,27 @@ async def api_chat_image(
     image: UploadFile = File(...),
 ) -> dict[str, Any]:
     api_key_plain = decrypt_user_key(encrypted_api_key)
-    _ = conversation_id  # forwarded with multi-turn memory in issue #6
     raw = await image.read()
     if not raw:
         raise HTTPException(status_code=400, detail="Empty image upload")
     media = image.content_type or "application/octet-stream"
-    reply, conv_id = run_nutrition_image_chat(api_key_plain, media, raw, message or None)
+    cid = conversation_id.strip() if conversation_id else None
+    reply, conv_id = run_nutrition_image_chat(
+        api_key_plain,
+        media,
+        raw,
+        message or None,
+        cid,
+    )
     return {"reply": reply, "conversation_id": conv_id}
+
+
+@app.post("/api/chat/reset")
+async def api_chat_reset(body: ResetBody, _: None = DependsPassword) -> dict[str, Any]:
+    _ = decrypt_user_key(body.encrypted_api_key)
+    cid = body.conversation_id.strip()
+    if not cid:
+        raise HTTPException(status_code=400, detail="conversation_id required")
+    reset_conversation(cid)
+    return {"ok": True, "conversation_id": cid}
 

--- a/backend/nutrition_graph.py
+++ b/backend/nutrition_graph.py
@@ -1,4 +1,4 @@
-"""LangGraph agent: Claude + nutrition system prompt."""
+"""LangGraph agent: Claude + nutrition system prompt + multi-turn memory per conversation_id."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import base64
 import uuid
 
 from langchain_anthropic import ChatAnthropic
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, START, MessagesState, StateGraph
 
@@ -17,6 +17,9 @@ When analyzing food images, provide detailed nutritional estimates."""
 MODEL_NAME = "claude-sonnet-4-20250514"
 
 _graph = None
+
+# In-memory transcripts (lost on restart; single-worker assumption for MVP).
+_conversation_histories: dict[str, list[BaseMessage]] = {}
 
 
 def _call_model(state: MessagesState, config: RunnableConfig) -> dict:
@@ -52,12 +55,25 @@ def _assistant_text_from_result(out: dict) -> str:
     return body if isinstance(body, str) else str(body)
 
 
-def run_nutrition_chat(decrypted_api_key: str, user_message: str) -> tuple[str, str]:
-    """Return (assistant_text, conversation_id). Memory per session lands in issue #6."""
+def _resolve_conversation_id(conversation_id: str | None) -> str:
+    cid = conversation_id.strip() if conversation_id else ""
+    return cid or str(uuid.uuid4())
+
+
+def run_nutrition_chat(
+    decrypted_api_key: str,
+    user_message: str,
+    conversation_id: str | None,
+) -> tuple[str, str]:
     graph = get_graph()
+    cid = _resolve_conversation_id(conversation_id)
+    hist = _conversation_histories.setdefault(cid, [])
+    hist.append(HumanMessage(content=user_message))
     cfg: RunnableConfig = {"configurable": {"anthropic_api_key": decrypted_api_key}}
-    out = graph.invoke({"messages": [HumanMessage(content=user_message)]}, cfg)
-    return _assistant_text_from_result(out), str(uuid.uuid4())
+    out = graph.invoke({"messages": hist}, cfg)
+    merged = list(out["messages"])
+    _conversation_histories[cid] = merged
+    return _assistant_text_from_result(out), cid
 
 
 def run_nutrition_image_chat(
@@ -65,18 +81,28 @@ def run_nutrition_image_chat(
     media_type: str,
     image_bytes: bytes,
     user_caption: str | None,
+    conversation_id: str | None,
 ) -> tuple[str, str]:
-    """Vision: food image + optional caption. Same graph; multimodal HumanMessage."""
     caption = (user_caption or "").strip()
     if not caption:
         caption = "Describe this food and estimate nutrition (calories and macros)."
     b64 = base64.b64encode(image_bytes).decode("ascii")
     media = media_type.strip() if media_type else "application/octet-stream"
-    content = [
+    content: list[str | dict] = [
         {"type": "text", "text": caption},
         {"type": "image_url", "image_url": {"url": f"data:{media};base64,{b64}"}},
     ]
     graph = get_graph()
+    cid = _resolve_conversation_id(conversation_id)
+    hist = _conversation_histories.setdefault(cid, [])
+    hist.append(HumanMessage(content=content))
     cfg: RunnableConfig = {"configurable": {"anthropic_api_key": decrypted_api_key}}
-    out = graph.invoke({"messages": [HumanMessage(content=content)]}, cfg)
-    return _assistant_text_from_result(out), str(uuid.uuid4())
+    out = graph.invoke({"messages": hist}, cfg)
+    merged = list(out["messages"])
+    _conversation_histories[cid] = merged
+    return _assistant_text_from_result(out), cid
+
+
+def reset_conversation(conversation_id: str) -> None:
+    if conversation_id:
+        _conversation_histories.pop(conversation_id.strip(), None)

--- a/backend/tests/test_memory_reset.py
+++ b/backend/tests/test_memory_reset.py
@@ -1,0 +1,98 @@
+"""Multi-turn conversation and /api/chat/reset."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage
+
+from crypto_util import encrypt_cryptojs_openssl
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    lens: list[int] = []
+
+    def fake_invoke(self, messages, *args, **kwargs):  # noqa: ANN001
+        lens.append(len(messages))
+        return AIMessage(content=f"reply-with-{len(messages)}-msgs")
+
+    monkeypatch.setattr("langchain_anthropic.ChatAnthropic.invoke", fake_invoke)
+
+    import nutrition_graph as ng
+
+    ng._conversation_histories.clear()
+
+    from main import app
+
+    c = TestClient(app)
+    c._dummy_lens = lens  # type: ignore[attr-defined]
+    return c
+
+
+@pytest.fixture
+def enc() -> str:
+    return encrypt_cryptojs_openssl("sk-test", "test-shared-secret-for-pytest-only!!")
+
+
+def test_multi_turn_second_call_has_more_messages(client: TestClient, enc: str) -> None:
+    lens: list[int] = client._dummy_lens  # type: ignore[union-attr]
+
+    r1 = client.post(
+        "/api/chat",
+        json={"encrypted_api_key": enc, "message": "hello"},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    assert r1.status_code == 200
+    cid = r1.json()["conversation_id"]
+
+    client.post(
+        "/api/chat",
+        json={"encrypted_api_key": enc, "message": "follow-up", "conversation_id": cid},
+        headers={"X-App-Password": "test-app-password"},
+    )
+
+    assert len(lens) >= 2
+    assert lens[1] > lens[0]
+
+
+def test_reset_then_same_id_starts_clean(client: TestClient, enc: str) -> None:
+    lens: list[int] = client._dummy_lens  # type: ignore[union-attr]
+
+    r1 = client.post(
+        "/api/chat",
+        json={"encrypted_api_key": enc, "message": "hello"},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    cid = r1.json()["conversation_id"]
+    first_len = lens[0]
+
+    client.post(
+        "/api/chat",
+        json={"encrypted_api_key": enc, "message": "second", "conversation_id": cid},
+        headers={"X-App-Password": "test-app-password"},
+    )
+
+    rr = client.post(
+        "/api/chat/reset",
+        json={"encrypted_api_key": enc, "conversation_id": cid},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    assert rr.status_code == 200
+
+    client.post(
+        "/api/chat",
+        json={"encrypted_api_key": enc, "message": "after-reset", "conversation_id": cid},
+        headers={"X-App-Password": "test-app-password"},
+    )
+
+    assert lens[-1] == first_len
+
+
+def test_reset_missing_conversation_id(client: TestClient, enc: str) -> None:
+    r = client.post(
+        "/api/chat/reset",
+        json={"encrypted_api_key": enc, "conversation_id": "   "},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
## Summary

- In-memory transcripts per `conversation_id`; `POST /api/chat/reset` clears a thread.
- `POST /api/chat` and `/api/chat/image` honor `conversation_id`.

Closes #6