### PR TITLE
#8: Frontend API key setup + CryptoJS + localStorage

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,7 @@
-# Backend API (used once the frontend connects in later issues)
-# NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+# Same value as backend `ENCRYPTION_SECRET` — browser encrypts the API key before localStorage (CryptoJS / OpenSSL salted AES).
+NEXT_PUBLIC_ENCRYPTION_SECRET=
+
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+
+# Same value as backend `APP_PASSWORD`; sent as `X-App-Password` once the frontend calls the API.
+NEXT_PUBLIC_APP_PASSWORD=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # Frontend
 
-**Next.js 14** (App Router) · **Tailwind CSS** · **[shadcn/ui](https://ui.shadcn.com/)** — scaffold for issue **#7**.
+**Next.js 14** (App Router) · **Tailwind CSS** · **[shadcn/ui](https://ui.shadcn.com/)** · **crypto-js** (CryptoJS-compatible AES for API keys).
 
 ## Scripts
 
@@ -12,10 +12,19 @@ npm run start
 npm run lint
 ```
 
-## Stack notes
+## Configuration
 
-- **Tailwind CSS v3** theme tokens wired for shadcn-style CSS variables (`app/globals.css` + `tailwind.config.ts`).
-- Import alias: `@/` → project root (`components.json`, `tsconfig.json`).
-- **`components/ui/button.tsx`**: Radix `Slot` + `class-variance-authority` (classic shadcn pattern). Add more components with `npx shadcn@latest add …` locally as needed.
+Copy `.env.example` to `.env.local` at minimum:
 
-Later issues wire the API client, encryption, chat, uploads, and tests.
+| Variable | Purpose |
+|----------|---------|
+| `NEXT_PUBLIC_ENCRYPTION_SECRET` | **Must equal** backend `ENCRYPTION_SECRET`. Used client-side only to encrypt the Anthropic API key before `localStorage`; never uploaded as plain text. |
+| `NEXT_PUBLIC_API_BASE_URL` | Backend URL (defaults reasonable for local FastAPI when wiring chat). |
+| `NEXT_PUBLIC_APP_PASSWORD` | **Must equal** backend `APP_PASSWORD`; used as `X-App-Password` on API calls once connected. |
+
+## Features
+
+- **`/`** — Landing with link to setup.
+- **`/setup`** — Enter Anthropic API key → **`CryptoJS.AES.encrypt(...).toString()`** → ciphertext stored under `lib/encryptedApiKey.ts` storage key (`diet_ai_encrypted_api_key_v1`). Matches `decrypt_cryptojs_openssl` in `backend/crypto_util.py`.
+
+Later issues wire the chat UI, multipart image upload, and Vitest around this encryption path.

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import { Button } from "@/components/ui/button";
 
 export default function Home() {
@@ -6,10 +8,15 @@ export default function Home() {
       <div className="text-center space-y-2 max-w-md">
         <h1 className="text-2xl font-semibold tracking-tight">Diet &amp; Nutrition AI</h1>
         <p className="text-sm text-muted-foreground">
-          Next.js 14 · Tailwind CSS · shadcn/ui scaffold (issue #7). Chat UI follows in later issues.
+          Configure your encrypted Anthropic API key (stored in the browser only), then continue to chat
+          when it ships.
         </p>
       </div>
-      <Button type="button">shadcn/ui wired</Button>
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Button asChild>
+          <Link href="/setup">API key setup</Link>
+        </Button>
+      </div>
     </main>
   );
 }

--- a/frontend/app/setup/page.tsx
+++ b/frontend/app/setup/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  clearStoredEncryptedApiKey,
+  encryptApiKey,
+  getStoredEncryptedApiKey,
+  hasEncryptionConfigured,
+  setStoredEncryptedApiKey,
+} from "@/lib/encryptedApiKey";
+
+export default function SetupPage() {
+  const [plaintextKey, setPlaintextKey] = useState("");
+  const [stored, setStored] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setStored(Boolean(getStoredEncryptedApiKey()?.trim()));
+  }, []);
+
+  const secret = process.env.NEXT_PUBLIC_ENCRYPTION_SECRET?.trim();
+
+  function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!plaintextKey.trim()) {
+      setError("Enter your Anthropic API key.");
+      return;
+    }
+    if (!secret) {
+      setError(
+        "Missing NEXT_PUBLIC_ENCRYPTION_SECRET (must match backend ENCRYPTION_SECRET). Add it to .env.local and restart."
+      );
+      return;
+    }
+    try {
+      const enc = encryptApiKey(plaintextKey, secret);
+      setStoredEncryptedApiKey(enc);
+      setStored(true);
+      setPlaintextKey("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Encryption failed.");
+    }
+  }
+
+  function handleClear() {
+    clearStoredEncryptedApiKey();
+    setStored(false);
+    setPlaintextKey("");
+    setError(null);
+  }
+
+  return (
+    <main className="min-h-dvh flex flex-col items-center justify-center p-6 bg-background">
+      <div className="w-full max-w-md space-y-6 rounded-xl border border-border bg-card p-6 text-card-foreground shadow-sm">
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold tracking-tight">API key setup</h1>
+          <p className="text-sm text-muted-foreground">
+            Your key is encrypted in the browser with{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">CryptoJS.AES.encrypt</code>{" "}
+            (same format as backend <code className="rounded bg-muted px-1 py-0.5 text-xs">decrypt_cryptojs_openssl</code>
+            ).
+            Only the ciphertext is kept in{" "}
+            <code className="rounded bg-muted px-1 py-0.5 text-xs">localStorage</code>.
+          </p>
+        </div>
+
+        {!hasEncryptionConfigured() ? (
+          <p className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            Set{" "}
+            <code className="font-mono text-xs">NEXT_PUBLIC_ENCRYPTION_SECRET</code> to the same value
+            as backend <code className="font-mono text-xs">ENCRYPTION_SECRET</code> (copy from{" "}
+            <code className="font-mono text-xs">frontend/.env.example</code>), then restart{" "}
+            <code className="font-mono text-xs">npm run dev</code>.
+          </p>
+        ) : null}
+
+        {stored ? (
+          <p className="text-sm font-medium text-foreground">
+            Saved: an encrypted API key is stored on this device.
+          </p>
+        ) : null}
+
+        <form onSubmit={handleSave} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="api-key" className="text-sm font-medium leading-none">
+              Anthropic API key
+            </label>
+            <Input
+              id="api-key"
+              type="password"
+              autoComplete="off"
+              value={plaintextKey}
+              onChange={(e) => setPlaintextKey(e.target.value)}
+              placeholder="sk-ant-api03-..."
+            />
+          </div>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          <div className="flex flex-wrap gap-2">
+            <Button type="submit">Encrypt & save</Button>
+            <Button type="button" variant="outline" onClick={handleClear} disabled={!stored}>
+              Clear saved key
+            </Button>
+          </div>
+        </form>
+
+        <Button variant="ghost" className="w-full" asChild>
+          <Link href="/">&larr; Back to home</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/frontend/lib/encryptedApiKey.ts
+++ b/frontend/lib/encryptedApiKey.ts
@@ -1,0 +1,33 @@
+import CryptoJS from "crypto-js";
+
+/** localStorage entry for ciphertext (OpenSSL salted format, decryptable by backend `crypto_util`). */
+export const ENCRYPTED_API_KEY_STORAGE_KEY = "diet_ai_encrypted_api_key_v1";
+
+/**
+ * Encrypt plaintext for `encrypted_api_key` payloads. Matches
+ * ``CryptoJS.AES.encrypt(plain, passphrase).toString()`` and backend `encrypt_cryptojs_openssl`.
+ */
+export function encryptApiKey(plaintext: string, passphrase: string): string {
+  return CryptoJS.AES.encrypt(plaintext.trim(), passphrase).toString();
+}
+
+export function hasEncryptionConfigured(): boolean {
+  return Boolean(process.env.NEXT_PUBLIC_ENCRYPTION_SECRET?.trim());
+}
+
+export function getStoredEncryptedApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage.getItem(ENCRYPTED_API_KEY_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setStoredEncryptedApiKey(ciphertext: string): void {
+  localStorage.setItem(ENCRYPTED_API_KEY_STORAGE_KEY, ciphertext);
+}
+
+export function clearStoredEncryptedApiKey(): void {
+  localStorage.removeItem(ENCRYPTED_API_KEY_STORAGE_KEY);
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@radix-ui/react-slot": "^1.1.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "crypto-js": "^4.2.0",
         "lucide-react": "^0.468.0",
         "next": "14.2.35",
         "react": "^18",
@@ -18,6 +19,7 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
+        "@types/crypto-js": "^4.2.2",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -568,6 +570,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmmirror.com/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1774,6 +1783,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@radix-ui/react-slot": "^1.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "crypto-js": "^4.2.0",
     "lucide-react": "^0.468.0",
     "next": "14.2.35",
     "react": "^18",
@@ -19,6 +20,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@types/crypto-js": "^4.2.2",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION
Closes #8

## Summary
- **`/setup`** — password field for the Anthropic API key, encrypts with **`CryptoJS.AES.encrypt(plain, passphrase).toString()`** using **`NEXT_PUBLIC_ENCRYPTION_SECRET`** (must match backend **`ENCRYPTION_SECRET`**).
- **`lib/encryptedApiKey.ts`** — encrypt helper + `localStorage` accessors under `diet_ai_encrypted_api_key_v1` (ciphertext only).
- **`components/ui/input.tsx`** — minimal text input aligned with existing theme tokens.
- Home page links to setup; **`.env.example`** and **`frontend/README.md`** document `NEXT_PUBLIC_*` variables (including `NEXT_PUBLIC_APP_PASSWORD` for issue #9).

## Verification
- `cd frontend && npm run build` · `npm run lint`