### PR TITLE
#9: Frontend chat UI + conversation reset

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,7 +24,8 @@ Copy `.env.example` to `.env.local` at minimum:
 
 ## Features
 
-- **`/`** — Landing with link to setup.
-- **`/setup`** — Enter Anthropic API key → **`CryptoJS.AES.encrypt(...).toString()`** → ciphertext stored under `lib/encryptedApiKey.ts` storage key (`diet_ai_encrypted_api_key_v1`). Matches `decrypt_cryptojs_openssl` in `backend/crypto_util.py`.
+- **`/`** — Landing with links to setup and chat.
+- **`/setup`** — Enter Anthropic API key → **`CryptoJS.AES.encrypt(...).toString()`** → ciphertext stored under `lib/encryptedApiKey.ts` (`diet_ai_encrypted_api_key_v1`).
+- **`/chat`** — Text chat (`POST /api/chat`) with bubbles, loading, **`conversation_id`** continuity, and **`Reset thread`** calling `POST /api/chat/reset`. Requires **`NEXT_PUBLIC_APP_PASSWORD`** (`X-App-Password`) plus a saved encrypted key.
 
-Later issues wire the chat UI, multipart image upload, and Vitest around this encryption path.
+Next issues: multipart food photo (`/api/chat/image`), Vitest coverage.

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { getApiBaseUrl, resetConversation as resetRemote, sendChatMessage } from "@/lib/chatApi";
+import { getStoredEncryptedApiKey } from "@/lib/encryptedApiKey";
+
+type ChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+};
+
+export default function ChatPage() {
+  const [mounted, setMounted] = useState(false);
+  const [encryptedKey, setEncryptedKey] = useState<string | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+    setEncryptedKey(getStoredEncryptedApiKey()?.trim() ?? null);
+  }, []);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, loading]);
+
+  const appendMessage = useCallback((msg: Omit<ChatMessage, "id">) => {
+    setMessages((prev) => [...prev, { ...msg, id: crypto.randomUUID() }]);
+  }, []);
+
+  async function submitMessage() {
+    setError(null);
+    const text = draft.trim();
+    if (!text || loading) return;
+    const key = encryptedKey?.trim();
+    if (!key) {
+      setError("No API key configured. Visit setup first.");
+      return;
+    }
+    appendMessage({ role: "user", content: text });
+    setDraft("");
+    setLoading(true);
+    try {
+      const data = await sendChatMessage({
+        encryptedApiKey: key,
+        message: text,
+        conversationId: conversationId ?? undefined,
+      });
+      appendMessage({ role: "assistant", content: data.reply });
+      setConversationId(data.conversation_id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleReset() {
+    setError(null);
+    const key = encryptedKey?.trim();
+    if (!conversationId?.trim()) {
+      setMessages([]);
+      setConversationId(null);
+      return;
+    }
+    if (!key) {
+      setError("No API key configured.");
+      return;
+    }
+    setLoading(true);
+    try {
+      await resetRemote(key, conversationId);
+      setMessages([]);
+      setConversationId(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Reset failed.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const hasKey = Boolean(encryptedKey);
+
+  return (
+    <main className="flex min-h-dvh flex-col bg-background">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+        <div>
+          <h1 className="text-lg font-semibold tracking-tight">Chat</h1>
+          <p className="text-xs text-muted-foreground">
+            Backend:{" "}
+            <code className="rounded bg-muted px-1 py-px text-[11px]" suppressHydrationWarning>
+              {getApiBaseUrl()}
+            </code>
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button type="button" variant="outline" size="sm" disabled={loading} onClick={() => handleReset()}>
+            Reset thread
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/setup">API key</Link>
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/">Home</Link>
+          </Button>
+        </div>
+      </header>
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {!mounted ? (
+          <div className="flex flex-1 items-center justify-center p-8 text-muted-foreground text-sm">Loading…</div>
+        ) : !hasKey ? (
+          <div className="m-4 rounded-lg border border-border bg-muted/40 px-4 py-6 text-center text-sm">
+            <p className="font-medium text-foreground">Encrypted API key not found</p>
+            <p className="mt-1 text-muted-foreground">Save one on the setup screen, then come back.</p>
+            <Button className="mt-4" asChild>
+              <Link href="/setup">Go to API key setup</Link>
+            </Button>
+          </div>
+        ) : (
+          <>
+            <section
+              className="flex-1 overflow-y-auto px-4 py-4"
+              aria-label="Conversation"
+            >
+              {messages.length === 0 ? (
+                <p className="mx-auto max-w-xl text-center text-sm text-muted-foreground">
+                  Ask anything about nutrition, meals, macros, or diet goals — messages stay in memory until you
+                  reset or refresh the page.
+                </p>
+              ) : (
+                <ul className="mx-auto flex max-w-xl flex-col gap-3">
+                  {messages.map((m) => (
+                    <li key={m.id} className={m.role === "user" ? "flex justify-end" : "flex justify-start"}>
+                      <div
+                        className={
+                          m.role === "user"
+                            ? "max-w-[85%] rounded-2xl rounded-br-md bg-primary px-3 py-2 text-primary-foreground"
+                            : "max-w-[85%] rounded-2xl rounded-bl-md bg-muted px-3 py-2 text-foreground whitespace-pre-wrap"
+                        }
+                      >
+                        {m.content}
+                      </div>
+                    </li>
+                  ))}
+                  <div ref={endRef} />
+                </ul>
+              )}
+              {conversationId ? (
+                <p className="mt-6 text-center text-[11px] text-muted-foreground">
+                  Conversation <code className="rounded bg-muted px-1">{conversationId.slice(0, 8)}…</code>
+                </p>
+              ) : null}
+            </section>
+
+            {error ? (
+              <div className="border-t border-border bg-destructive/10 px-4 py-2 text-center text-sm text-destructive">
+                {error}
+              </div>
+            ) : null}
+
+            <form
+              className="border-t border-border bg-card p-4"
+              onSubmit={(e) => {
+                e.preventDefault();
+                void submitMessage();
+              }}
+            >
+              <div className="mx-auto flex max-w-xl flex-col gap-2">
+                <Textarea
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  placeholder="Type a message…"
+                  rows={3}
+                  disabled={loading}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && !e.shiftKey) {
+                      e.preventDefault();
+                      void submitMessage();
+                    }
+                  }}
+                  className="resize-none"
+                  aria-label="Message"
+                />
+                <div className="flex justify-end gap-2">
+                  <Button type="submit" disabled={loading || !draft.trim()}>
+                    {loading ? "Sending…" : "Send"}
+                  </Button>
+                </div>
+              </div>
+            </form>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -8,13 +8,16 @@ export default function Home() {
       <div className="text-center space-y-2 max-w-md">
         <h1 className="text-2xl font-semibold tracking-tight">Diet &amp; Nutrition AI</h1>
         <p className="text-sm text-muted-foreground">
-          Configure your encrypted Anthropic API key (stored in the browser only), then continue to chat
-          when it ships.
+          Configure your encrypted Anthropic API key, then open chat — all on device; backend uses your key for
+          model calls.
         </p>
       </div>
       <div className="flex flex-wrap items-center justify-center gap-3">
         <Button asChild>
           <Link href="/setup">API key setup</Link>
+        </Button>
+        <Button asChild variant="secondary">
+          <Link href="/chat">Open chat</Link>
         </Button>
       </div>
     </main>

--- a/frontend/app/setup/page.tsx
+++ b/frontend/app/setup/page.tsx
@@ -108,9 +108,16 @@ export default function SetupPage() {
           </div>
         </form>
 
-        <Button variant="ghost" className="w-full" asChild>
-          <Link href="/">&larr; Back to home</Link>
-        </Button>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Button variant="ghost" className="flex-1" asChild>
+            <Link href="/">&larr; Home</Link>
+          </Button>
+          {stored ? (
+            <Button className="flex-1" asChild>
+              <Link href="/chat">Open chat</Link>
+            </Button>
+          ) : null}
+        </div>
       </div>
     </main>
   );

--- a/frontend/components/ui/textarea.tsx
+++ b/frontend/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/frontend/lib/chatApi.ts
+++ b/frontend/lib/chatApi.ts
@@ -1,0 +1,92 @@
+/**
+ * Backend text chat + reset (multipart image is issue #10).
+ */
+
+export function getApiBaseUrl(): string {
+  const raw = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+  return raw.replace(/\/$/, "");
+}
+
+export function getAppPassword(): string | undefined {
+  const p = process.env.NEXT_PUBLIC_APP_PASSWORD?.trim();
+  return p || undefined;
+}
+
+function stringifyDetail(data: unknown): string {
+  if (data === null || data === undefined) return "";
+  if (typeof data === "string") return data;
+  if (typeof data === "number" || typeof data === "boolean") return String(data);
+  try {
+    return JSON.stringify(data);
+  } catch {
+    return String(data);
+  }
+}
+
+async function parseErrorResponse(res: Response): Promise<string> {
+  try {
+    const raw = await res.text();
+    if (!raw) return res.statusText || `HTTP ${res.status}`;
+    const j = JSON.parse(raw) as { detail?: unknown };
+    const d = j.detail;
+    if (typeof d === "string") return d;
+    if (Array.isArray(d)) {
+      return d
+        .map((item: { msg?: string }) => item?.msg ?? JSON.stringify(item))
+        .join("; ");
+    }
+    if (d !== undefined) return stringifyDetail(d);
+    return raw;
+  } catch {
+    return res.statusText || `HTTP ${res.status}`;
+  }
+}
+
+async function postAppJson<T>(path: string, body: Record<string, unknown>): Promise<T> {
+  const pwd = getAppPassword();
+  if (!pwd) {
+    throw new Error(
+      "NEXT_PUBLIC_APP_PASSWORD is not set. It must match the backend APP_PASSWORD (see frontend/.env.example)."
+    );
+  }
+  const url = `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-App-Password": pwd,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const msg = await parseErrorResponse(res);
+    throw new Error(msg || `Request failed (${res.status})`);
+  }
+  return (await res.json()) as T;
+}
+
+export type ChatPostResponse = { reply: string; conversation_id: string };
+
+export async function sendChatMessage(args: {
+  encryptedApiKey: string;
+  message: string;
+  conversationId?: string | null;
+}): Promise<ChatPostResponse> {
+  const body: Record<string, unknown> = {
+    encrypted_api_key: args.encryptedApiKey.trim(),
+    message: args.message,
+  };
+  const cid = args.conversationId?.trim();
+  if (cid) body.conversation_id = cid;
+  return postAppJson<ChatPostResponse>("/api/chat", body);
+}
+
+export async function resetConversation(
+  encryptedApiKey: string,
+  conversationId: string
+): Promise<{ ok: boolean; conversation_id: string }> {
+  return postAppJson<{ ok: boolean; conversation_id: string }>("/api/chat/reset", {
+    encrypted_api_key: encryptedApiKey.trim(),
+    conversation_id: conversationId.trim(),
+  });
+}


### PR DESCRIPTION
Closes #9

## Summary
- **`app/chat/page.tsx`** — Client chat: ordered message list (user / assistant bubbles), **`Sending…`** loading, error strip from backend `detail`, **Enter** to send (Shift+Enter newline).
- **`lib/chatApi.ts`** — **`POST /api/chat`** with `encrypted_api_key`, `message`, optional `conversation_id`; **`POST /api/chat/reset`**; **`X-App-Password`** via **`NEXT_PUBLIC_APP_PASSWORD`**; base URL **`NEXT_PUBLIC_API_BASE_URL`** (default `http://localhost:8000`).
- **Reset thread** clears UI and calls backend reset when a `conversation_id` exists; trivial clear if none yet.
- Empty state directs to **`/setup`** if no ciphertext in `localStorage`.
- **Home** + **setup** link to chat; **`components/ui/textarea`** for input.

## Verification
- `cd frontend && npm run build` · `npm run lint`

**Note:** Backend must be running with matching `APP_PASSWORD` / `ENCRYPTION_SECRET` vs frontend `.env.local`.
