### PR TITLE
#10: Frontend image upload for food photo analysis

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -26,6 +26,6 @@ Copy `.env.example` to `.env.local` at minimum:
 
 - **`/`** — Landing with links to setup and chat.
 - **`/setup`** — Enter Anthropic API key → **`CryptoJS.AES.encrypt(...).toString()`** → ciphertext stored under `lib/encryptedApiKey.ts` (`diet_ai_encrypted_api_key_v1`).
-- **`/chat`** — Text chat (`POST /api/chat`) with bubbles, loading, **`conversation_id`** continuity, and **`Reset thread`** calling `POST /api/chat/reset`. Requires **`NEXT_PUBLIC_APP_PASSWORD`** (`X-App-Password`) plus a saved encrypted key.
+- **`/chat`** — Text chat (`POST /api/chat`), optional **food photo** via multipart **`POST /api/chat/image`** (caption optional), **`conversation_id`** continuity, **`Reset thread`** (`POST /api/chat/reset`). Needs **`NEXT_PUBLIC_APP_PASSWORD`** and a saved encrypted key.
 
-Next issues: multipart food photo (`/api/chat/image`), Vitest coverage.
+Later: Vitest around encrypt + chat flows.

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -5,14 +5,26 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { getApiBaseUrl, resetConversation as resetRemote, sendChatMessage } from "@/lib/chatApi";
+import {
+  getApiBaseUrl,
+  resetConversation as resetRemote,
+  sendChatImage,
+  sendChatMessage,
+} from "@/lib/chatApi";
 import { getStoredEncryptedApiKey } from "@/lib/encryptedApiKey";
 
 type ChatMessage = {
   id: string;
   role: "user" | "assistant";
   content: string;
+  imagePreviewUrl?: string;
 };
+
+function revokeMessageImages(messages: ChatMessage[]) {
+  for (const m of messages) {
+    if (m.imagePreviewUrl) URL.revokeObjectURL(m.imagePreviewUrl);
+  }
+}
 
 export default function ChatPage() {
   const [mounted, setMounted] = useState(false);
@@ -20,10 +32,18 @@ export default function ChatPage() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
+  const [pendingImage, setPendingImage] = useState<{ file: File; previewUrl: string } | null>(
+    null
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const endRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const messagesRef = useRef<ChatMessage[]>(messages);
+  const pendingRef = useRef(pendingImage);
+  messagesRef.current = messages;
+  pendingRef.current = pendingImage;
 
   useEffect(() => {
     setMounted(true);
@@ -34,11 +54,18 @@ export default function ChatPage() {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, loading]);
 
+  useEffect(() => {
+    return () => {
+      revokeMessageImages(messagesRef.current);
+      if (pendingRef.current?.previewUrl) URL.revokeObjectURL(pendingRef.current.previewUrl);
+    };
+  }, []);
+
   const appendMessage = useCallback((msg: Omit<ChatMessage, "id">) => {
     setMessages((prev) => [...prev, { ...msg, id: crypto.randomUUID() }]);
   }, []);
 
-  async function submitMessage() {
+  async function submitTextMessage() {
     setError(null);
     const text = draft.trim();
     if (!text || loading) return;
@@ -65,9 +92,71 @@ export default function ChatPage() {
     }
   }
 
+  async function submitImageMessage() {
+    if (!pendingImage || loading) return;
+    setError(null);
+    const key = encryptedKey?.trim();
+    if (!key) {
+      setError("No API key configured. Visit setup first.");
+      return;
+    }
+    const caption = draft.trim();
+    const { file, previewUrl } = pendingImage;
+    appendMessage({
+      role: "user",
+      content: caption || "📷 Food photo",
+      imagePreviewUrl: previewUrl,
+    });
+    setDraft("");
+    setPendingImage(null);
+    setLoading(true);
+    try {
+      const data = await sendChatImage({
+        encryptedApiKey: key,
+        image: file,
+        message: caption || undefined,
+        conversationId: conversationId ?? undefined,
+        fileName: file.name,
+      });
+      appendMessage({ role: "assistant", content: data.reply });
+      setConversationId(data.conversation_id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitOutgoing() {
+    if (pendingImage) {
+      await submitImageMessage();
+    } else {
+      await submitTextMessage();
+    }
+  }
+
+  function onPickFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    e.target.value = "";
+    if (!f || !f.type.startsWith("image/")) return;
+    setPendingImage((prev) => {
+      if (prev?.previewUrl) URL.revokeObjectURL(prev.previewUrl);
+      return { file: f, previewUrl: URL.createObjectURL(f) };
+    });
+  }
+
+  function clearPendingImage() {
+    setPendingImage((prev) => {
+      if (prev?.previewUrl) URL.revokeObjectURL(prev.previewUrl);
+      return null;
+    });
+  }
+
   async function handleReset() {
     setError(null);
     const key = encryptedKey?.trim();
+    revokeMessageImages(messages);
+    clearPendingImage();
     if (!conversationId?.trim()) {
       setMessages([]);
       setConversationId(null);
@@ -90,6 +179,8 @@ export default function ChatPage() {
   }
 
   const hasKey = Boolean(encryptedKey);
+  const canSend =
+    !loading && (Boolean(draft.trim()) || Boolean(pendingImage));
 
   return (
     <main className="flex min-h-dvh flex-col bg-background">
@@ -129,14 +220,10 @@ export default function ChatPage() {
           </div>
         ) : (
           <>
-            <section
-              className="flex-1 overflow-y-auto px-4 py-4"
-              aria-label="Conversation"
-            >
+            <section className="flex-1 overflow-y-auto px-4 py-4" aria-label="Conversation">
               {messages.length === 0 ? (
                 <p className="mx-auto max-w-xl text-center text-sm text-muted-foreground">
-                  Ask anything about nutrition, meals, macros, or diet goals — messages stay in memory until you
-                  reset or refresh the page.
+                  Ask about nutrition or attach a photo of food for analysis — thread stays until you reset or refresh.
                 </p>
               ) : (
                 <ul className="mx-auto flex max-w-xl flex-col gap-3">
@@ -149,6 +236,13 @@ export default function ChatPage() {
                             : "max-w-[85%] rounded-2xl rounded-bl-md bg-muted px-3 py-2 text-foreground whitespace-pre-wrap"
                         }
                       >
+                        {m.role === "user" && m.imagePreviewUrl ? (
+                          <div className="mb-2 overflow-hidden rounded-lg">
+                            {/* Blob URLs — next/image optimizer not applicable */}
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img alt="" src={m.imagePreviewUrl} className="max-h-56 w-full object-cover" />
+                          </div>
+                        ) : null}
                         {m.content}
                       </div>
                     </li>
@@ -173,28 +267,63 @@ export default function ChatPage() {
               className="border-t border-border bg-card p-4"
               onSubmit={(e) => {
                 e.preventDefault();
-                void submitMessage();
+                void submitOutgoing();
               }}
             >
+              <input
+                ref={fileInputRef}
+                type="file"
+                className="sr-only"
+                accept="image/*"
+                aria-label="Choose food photo"
+                onChange={onPickFile}
+              />
               <div className="mx-auto flex max-w-xl flex-col gap-2">
+                {pendingImage ? (
+                  <div className="relative flex items-start gap-3 rounded-lg border border-border bg-muted/30 p-2">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      alt=""
+                      src={pendingImage.previewUrl}
+                      className="h-20 w-20 shrink-0 rounded-md border border-border object-cover"
+                    />
+                    <div className="min-w-0 flex-1 text-xs text-muted-foreground">
+                      <p className="truncate font-medium text-foreground">{pendingImage.file.name}</p>
+                      <p>Uses vision endpoint. Add an optional caption below, then send.</p>
+                    </div>
+                    <Button type="button" variant="outline" size="sm" className="shrink-0" onClick={clearPendingImage}>
+                      Remove
+                    </Button>
+                  </div>
+                ) : null}
                 <Textarea
                   value={draft}
                   onChange={(e) => setDraft(e.target.value)}
-                  placeholder="Type a message…"
+                  placeholder={
+                    pendingImage ? "Optional caption (e.g. rough portion size)" : "Type a message…"
+                  }
                   rows={3}
                   disabled={loading}
                   onKeyDown={(e) => {
                     if (e.key === "Enter" && !e.shiftKey) {
                       e.preventDefault();
-                      void submitMessage();
+                      if (canSend) void submitOutgoing();
                     }
                   }}
                   className="resize-none"
                   aria-label="Message"
                 />
-                <div className="flex justify-end gap-2">
-                  <Button type="submit" disabled={loading || !draft.trim()}>
-                    {loading ? "Sending…" : "Send"}
+                <div className="flex flex-wrap justify-between gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={loading}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    Photo
+                  </Button>
+                  <Button type="submit" disabled={!canSend}>
+                    {loading ? "Sending…" : pendingImage ? "Send photo" : "Send"}
                   </Button>
                 </div>
               </div>

--- a/frontend/lib/chatApi.ts
+++ b/frontend/lib/chatApi.ts
@@ -1,5 +1,5 @@
 /**
- * Backend text chat + reset (multipart image is issue #10).
+ * Backend text chat, image upload, and reset.
  */
 
 export function getApiBaseUrl(): string {
@@ -42,6 +42,28 @@ async function parseErrorResponse(res: Response): Promise<string> {
   }
 }
 
+async function postAppFormData<T>(path: string, formData: FormData): Promise<T> {
+  const pwd = getAppPassword();
+  if (!pwd) {
+    throw new Error(
+      "NEXT_PUBLIC_APP_PASSWORD is not set. It must match the backend APP_PASSWORD (see frontend/.env.example)."
+    );
+  }
+  const url = `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "X-App-Password": pwd,
+    },
+    body: formData,
+  });
+  if (!res.ok) {
+    const msg = await parseErrorResponse(res);
+    throw new Error(msg || `Request failed (${res.status})`);
+  }
+  return (await res.json()) as T;
+}
+
 async function postAppJson<T>(path: string, body: Record<string, unknown>): Promise<T> {
   const pwd = getAppPassword();
   if (!pwd) {
@@ -79,6 +101,26 @@ export async function sendChatMessage(args: {
   const cid = args.conversationId?.trim();
   if (cid) body.conversation_id = cid;
   return postAppJson<ChatPostResponse>("/api/chat", body);
+}
+
+/** Multipart upload to `POST /api/chat/image` (vision). */
+export async function sendChatImage(args: {
+  encryptedApiKey: string;
+  image: File | Blob;
+  message?: string | null;
+  conversationId?: string | null;
+  fileName?: string;
+}): Promise<ChatPostResponse> {
+  const fd = new FormData();
+  fd.append("encrypted_api_key", args.encryptedApiKey.trim());
+  const cid = args.conversationId?.trim();
+  if (cid) fd.append("conversation_id", cid);
+  fd.append("message", (args.message ?? "").trim());
+  const name =
+    args.fileName ??
+    (args.image instanceof File ? args.image.name : "upload");
+  fd.append("image", args.image, name);
+  return postAppFormData<ChatPostResponse>("/api/chat/image", fd);
 }
 
 export async function resetConversation(


### PR DESCRIPTION
Closes #10

## Summary
- **`lib/chatApi.ts`**: `postAppFormData` + **`sendChatImage`** — `FormData` with `encrypted_api_key`, optional `conversation_id` + `message`, file field **`image`** matching `POST /api/chat/image`; **`X-App-Password`** only (no JSON `Content-Type`).
- **`/chat`**: **Photo** opens `accept="image/*"` picker, inline preview + **Remove**; **Send photo** / Enter uses vision path when a file is staged; optional caption from textarea; **`conversation_id`** passed through; user bubble shows image + caption; **Reset thread** revokes blob URLs and clears pending selection.
- **`frontend/README.md`**: documents multipart flow.

## Verification
- `cd frontend && npm run build` · `npm run lint`
