### PR TITLE
#11: Backend Pytest coverage (health, auth, decrypt, edge cases)

### DIFF
--- a/backend/tests/test_chat_api.py
+++ b/backend/tests/test_chat_api.py
@@ -37,3 +37,33 @@ def test_chat_success(client: TestClient) -> None:
     data = r.json()
     assert data["reply"]
     assert "conversation_id" in data
+
+
+def test_get_health_requires_no_auth_and_returns_ok() -> None:
+    from main import app
+
+    c = TestClient(app)
+    r = c.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_chat_invalid_app_password_is_403(client: TestClient) -> None:
+    enc = encrypt_cryptojs_openssl("sk-test", "test-shared-secret-for-pytest-only!!")
+    r = client.post(
+        "/api/chat",
+        json={"encrypted_api_key": enc, "message": "Hi"},
+        headers={"X-App-Password": "wrong-password"},
+    )
+    assert r.status_code == 403
+
+
+def test_chat_invalid_ciphertext_is_400(client: TestClient) -> None:
+    r = client.post(
+        "/api/chat",
+        json={"encrypted_api_key": "not-openssl-salted-json", "message": "Hi"},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    assert r.status_code == 400
+    detail = r.json().get("detail") or ""
+    assert isinstance(detail, str) and ("decrypt" in detail.lower())

--- a/backend/tests/test_image_api.py
+++ b/backend/tests/test_image_api.py
@@ -52,3 +52,36 @@ def test_chat_image_success(client: TestClient) -> None:
     data = r.json()
     assert data.get("reply")
     assert data.get("conversation_id")
+
+
+def test_chat_image_invalid_app_password(client: TestClient) -> None:
+    enc = encrypt_cryptojs_openssl("sk-test", "test-shared-secret-for-pytest-only!!")
+    r = client.post(
+        "/api/chat/image",
+        data={"encrypted_api_key": enc},
+        files={"image": ("tiny.png", PNG_1X1_BYTES, "image/png")},
+        headers={"X-App-Password": "bogus"},
+    )
+    assert r.status_code == 403
+
+
+def test_chat_image_invalid_ciphertext_returns_400(client: TestClient) -> None:
+    r = client.post(
+        "/api/chat/image",
+        data={"encrypted_api_key": "not-a-valid-ciphertext", "conversation_id": ""},
+        files={"image": ("tiny.png", PNG_1X1_BYTES, "image/png")},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    assert r.status_code == 400
+
+
+def test_chat_image_empty_upload_is_400(client: TestClient) -> None:
+    enc = encrypt_cryptojs_openssl("sk-test", "test-shared-secret-for-pytest-only!!")
+    r = client.post(
+        "/api/chat/image",
+        data={"encrypted_api_key": enc},
+        files={"image": ("empty.png", b"", "image/png")},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    assert r.status_code == 400
+    assert "Empty image" in (r.json().get("detail") or "")

--- a/backend/tests/test_memory_reset.py
+++ b/backend/tests/test_memory_reset.py
@@ -96,3 +96,21 @@ def test_reset_missing_conversation_id(client: TestClient, enc: str) -> None:
         headers={"X-App-Password": "test-app-password"},
     )
     assert r.status_code == 400
+
+
+def test_reset_invalid_password_is_403(client: TestClient, enc: str) -> None:
+    r = client.post(
+        "/api/chat/reset",
+        json={"encrypted_api_key": enc, "conversation_id": "conversation-ignored"},
+        headers={"X-App-Password": "invalid-app-password"},
+    )
+    assert r.status_code == 403
+
+
+def test_reset_invalid_cipher_is_400(client: TestClient) -> None:
+    r = client.post(
+        "/api/chat/reset",
+        json={"encrypted_api_key": "not-real-ciphertext-at-all", "conversation_id": "valid-looking-id-string"},
+        headers={"X-App-Password": "test-app-password"},
+    )
+    assert r.status_code == 400


### PR DESCRIPTION
Closes #11

## Summary
- **`GET /health`** — Smoke check `{"status":"ok"}` without auth.
- **Auth (`403`)** — Wrong `X-App-Password` on `POST /api/chat`, multipart `/api/chat/image`, and `POST /api/chat/reset`.
- **Decryption (`400`)** — Bad `encrypted_api_key` ciphertext on `/api/chat`, `/api/chat/image`, and `/api/chat/reset` asserts `could not decrypt` / non-200 as appropriate.
- **Vision edge case** — Empty image body → `400` with “Empty image” detail.
- Existing mocks for **`ChatAnthropic.invoke`** plus LangGraph **`/api/chat/reset`** behavior remain unchanged.

## Verification
- `cd backend && python -m pytest -q` (17 tests).
