### PR TITLE
#13: GitHub Actions CI for backend (Ruff + pytest)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,45 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci.yml"
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Pytest
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ Private monorepo for the Diet & Nutrition AI Chat App.
 |------|---------|
 | `frontend/` | Next.js 14 (App Router) UI — wired in issues 7+ |
 | `backend/` | FastAPI + LangChain — wired in issues 2+ |
-| `.github/workflows/` | CI in issues 13–14 |
+| `.github/workflows/` | Backend: `backend-ci.yml` (#13); frontend CI #14 |
 
 See `frontend/README.md` (Next.js) and `backend/README.md` (FastAPI) for how to run each app.

--- a/backend/README.md
+++ b/backend/README.md
@@ -65,6 +65,12 @@ Same header **`X-App-Password`**. Response shape: `{ "reply", "conversation_id" 
 
 ## Tests
 
+Uses **`requirements-dev.txt`** (pytest + Ruff).
+
 ```bash
+pip install -r requirements.txt -r requirements-dev.txt
+ruff check .
 pytest tests/
 ```
+
+CI: `.github/workflows/backend-ci.yml` (paths under `backend/**`).

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Dev dependencies (CI and local tooling). Install after production deps:
+#
+#     pip install -r requirements.txt -r requirements-dev.txt
+
+pytest>=8.3
+ruff>=0.9.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,3 @@ langchain-core>=0.3.5
 langchain-anthropic>=0.3.0
 langgraph>=0.2.55
 httpx>=0.27.0,<0.28
-
-# dev/tests
-pytest>=8.3


### PR DESCRIPTION
Closes #13

## Summary
- **`.github/workflows/backend-ci.yml`** — On `push` / `pull_request` to `main`/`dev` when **`backend/**`** (or this workflow) changes: Python **3.12**, `pip install -r requirements.txt -r requirements-dev.txt`, **`ruff check .`**, **`pytest -q`** (`working-directory: backend`).
- **`backend/requirements-dev.txt`** — `pytest`, `ruff` for local + CI (install after main `requirements.txt`).
- **`backend/requirements.txt`** — runtime only (pytest removed from prod file).
- **Docs** — `backend/README.md` test section; root `README.md` layout table.

## Verification
- `cd backend && pip install -r requirements.txt -r requirements-dev.txt && ruff check . && pytest -q`
