### PR TITLE
#14: GitHub Actions CI for frontend (ESLint + Vitest)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,41 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: ESLint
+        run: npm run lint
+
+      - name: Vitest
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ Private monorepo for the Diet & Nutrition AI Chat App.
 |------|---------|
 | `frontend/` | Next.js 14 (App Router) UI — wired in issues 7+ |
 | `backend/` | FastAPI + LangChain — wired in issues 2+ |
-| `.github/workflows/` | Backend: `backend-ci.yml` (#13); frontend CI #14 |
+| `.github/workflows/` | `backend-ci.yml` (#13), `frontend-ci.yml` (#14) |
 
 See `frontend/README.md` (Next.js) and `backend/README.md` (FastAPI) for how to run each app.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,3 +36,5 @@ Copy `.env.example` to `.env.local` at minimum:
 - **`__tests__/chat-page.smoke.test.tsx`** — chat shell when a key exists; **Photo** + hidden file input.
 
 Config: `vitest.config.mjs`, `vitest.setup.ts` (maps `next/link`, stubs `ResizeObserver` / `scrollIntoView`).
+
+CI on `frontend/**`: `.github/workflows/frontend-ci.yml` (`npm ci`, `npm run lint`, `npm run test`).


### PR DESCRIPTION
Closes #14

## Summary
- **`.github/workflows/frontend-ci.yml`** — On `push` / `pull_request` to `main`/`dev` when **`frontend/**`** (or this workflow) changes: **Node 20**, **`npm ci`** (lockfile), **`npm run lint`**, **`npm run test`** (`working-directory: frontend`).
- **README** — Root layout table + `frontend/README.md` note pointing at the workflow.

## Verification
- `cd frontend && npm ci && npm run lint && npm run test`
