### PR TITLE
#15: Railway backend deploy config (railway.toml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Private monorepo for the Diet & Nutrition AI Chat App.
 | Path | Purpose |
 |------|---------|
 | `frontend/` | Next.js 14 (App Router) UI — wired in issues 7+ |
-| `backend/` | FastAPI + LangChain — wired in issues 2+ |
+| `backend/` | FastAPI + LangChain; **`railway.toml`** for Railway deploy (#15) |
 | `.github/workflows/` | `backend-ci.yml` (#13), `frontend-ci.yml` (#14) |
 
 See `frontend/README.md` (Next.js) and `backend/README.md` (FastAPI) for how to run each app.

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,6 +19,15 @@ Then open `GET http://127.0.0.1:8000/health` — expect `{ "status": "ok" }`.
 
 Copy `.env.example` to `.env` and set `APP_PASSWORD` and `ENCRYPTION_SECRET`.
 
+## Deploy (Railway) (issue **#15**)
+
+- **GitHub service** → set **Root Directory** to **`backend`** (reads `requirements.txt`, `railway.toml`, `main.py`).
+- **`backend/railway.toml`** — `uvicorn` on **`$PORT`**, **`GET /health`** for healthchecks.
+- **Variables** (same names as `.env.example`; set in Railway, not committed):
+  - **`APP_PASSWORD`** — must match the frontend **`NEXT_PUBLIC_APP_PASSWORD`** (`X-App-Password`).
+  - **`ENCRYPTION_SECRET`** — must match **`NEXT_PUBLIC_ENCRYPTION_SECRET`** so encrypted API keys decrypt.
+- **Note:** Conversation memory is **in-process** (`nutrition_graph`); use a **single replica** unless you swap storage later.
+
 ## Chat API (issue **#4**)
 
 `POST /api/chat` JSON body:

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -1,0 +1,10 @@
+# Config-as-code for Railway: create the service from this repo with
+# Root Directory set to `backend` (monorepo).
+# Docs: https://docs.railway.com/reference/config-as-code
+
+[build]
+builder = "RAILPACK"
+
+[deploy]
+startCommand = "uvicorn main:app --host 0.0.0.0 --port $PORT"
+healthcheckPath = "/health"


### PR DESCRIPTION
Closes #15

## Summary
- **`backend/railway.toml`** — **Railpack** builder; **`deploy.startCommand`** binds **uvicorn** to **`0.0.0.0:$PORT`**; **`healthcheckPath`** **`/health`**.
- **`backend/README.md`** — Deploy section: Railway service **Root Directory** = **`backend`**, required variables **`APP_PASSWORD`** + **`ENCRYPTION_SECRET`** (match frontend public envs), note on **single replica** for in-memory LangGraph histories.
- **Root `README.md`** — Layout row references `railway.toml`.

## Operator notes
Set env in the Railway dashboard from the same semantics as `backend/.env.example` (no server-side Anthropic API key; clients send encrypted keys).
