### PR TITLE
PostgreSQL/SQLite persistence, JWT auth, analytics dashboard

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -43,6 +43,6 @@ jobs:
 
       - name: Pytest
         env:
-          DATABASE_URL: sqlite:///:memory:
-          JWT_SECRET: ci-jwt-secret-must-be-at-least-32-characters
+          DATABASE_URL: "sqlite:///:memory:"
+          JWT_SECRET: "ci-jwt-secret-must-be-at-least-32-characters"
         run: pytest -q

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -42,4 +42,7 @@ jobs:
         run: ruff check .
 
       - name: Pytest
+        env:
+          DATABASE_URL: sqlite:///:memory:
+          JWT_SECRET: ci-jwt-secret-must-be-at-least-32-characters
         run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ npm-debug.log*
 .env
 .env.local
 .env.*.local
+*.db
+frontend/.npm-cache
 
 # OS / IDE
 .DS_Store

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,9 @@ ENCRYPTION_SECRET=change-me-same-as-frontend-passphrase
 
 # Shared secret; request header X-App-Password must match
 APP_PASSWORD=change-me-app-gate
+
+# PostgreSQL (Railway or local Docker). If unset, backend uses SQLite ./diet_ai.db
+# DATABASE_URL=postgresql://diet:diet@localhost:5432/diet_ai
+
+# Sign JWTs from POST /api/auth/login (use a long random value in production)
+JWT_SECRET=change-me-dev-jwt-secret-minimum-32-characters-long

--- a/backend/auth_tokens.py
+++ b/backend/auth_tokens.py
@@ -1,0 +1,32 @@
+"""Password hashing and JWT helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import bcrypt
+from jose import JWTError, jwt
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return bcrypt.checkpw(plain.encode("utf-8"), hashed.encode("utf-8"))
+
+
+def create_access_token(*, subject_user_id: str, secret: str, expires_hours: int) -> str:
+    expire = datetime.utcnow() + timedelta(hours=expires_hours)
+    return jwt.encode({"sub": subject_user_id, "exp": expire}, secret, algorithm="HS256")
+
+
+def decode_access_token(token: str, secret: str) -> str:
+    try:
+        payload = jwt.decode(token, secret, algorithms=["HS256"])
+        sub = payload.get("sub")
+        if not isinstance(sub, str) or not sub:
+            raise JWTError("missing sub")
+        return sub
+    except JWTError as exc:
+        raise ValueError("Invalid token") from exc

--- a/backend/conversation_store.py
+++ b/backend/conversation_store.py
@@ -1,0 +1,151 @@
+"""Load/save chat turns for authenticated users (PostgreSQL or SQLite)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import HTTPException
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from sqlalchemy.orm import Session
+
+from models import Conversation, Message
+from nutrition_graph import invoke_graph_with_messages
+
+
+def db_messages_to_lc(rows: list[Message]) -> list[BaseMessage]:
+    out: list[BaseMessage] = []
+    for m in rows:
+        if m.role == "user":
+            out.append(HumanMessage(content=m.content))
+        elif m.role == "assistant":
+            out.append(AIMessage(content=m.content))
+    return out
+
+
+def get_or_create_conversation(
+    db: Session,
+    user_id: str,
+    conversation_id: str | None,
+) -> Conversation:
+    cid = conversation_id.strip() if conversation_id else ""
+    if cid:
+        conv = (
+            db.query(Conversation)
+            .filter(Conversation.id == cid, Conversation.user_id == user_id)
+            .first()
+        )
+        if not conv:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        return conv
+    conv = Conversation(user_id=user_id, title="New chat")
+    db.add(conv)
+    db.commit()
+    db.refresh(conv)
+    return conv
+
+
+def run_persisted_text_chat(
+    db: Session,
+    user_id: str,
+    conversation_id: str | None,
+    user_message: str,
+    api_key_plain: str,
+) -> tuple[str, str]:
+    conv = get_or_create_conversation(db, user_id, conversation_id)
+    rows = (
+        db.query(Message)
+        .filter(Message.conversation_id == conv.id)
+        .order_by(Message.created_at.asc())
+        .all()
+    )
+    lc_hist = db_messages_to_lc(rows)
+    lc_hist.append(HumanMessage(content=user_message))
+    reply, _merged = invoke_graph_with_messages(api_key_plain, lc_hist)
+    db.add(
+        Message(
+            conversation_id=conv.id,
+            role="user",
+            content=user_message,
+            has_image=False,
+        )
+    )
+    db.add(
+        Message(
+            conversation_id=conv.id,
+            role="assistant",
+            content=reply,
+            has_image=False,
+        )
+    )
+    if conv.title == "New chat":
+        conv.title = user_message[:80] + ("…" if len(user_message) > 80 else "")
+    conv.updated_at = datetime.utcnow()
+    db.commit()
+    return reply, conv.id
+
+
+def run_persisted_image_chat(
+    db: Session,
+    user_id: str,
+    conversation_id: str | None,
+    media_type: str,
+    image_bytes: bytes,
+    user_caption: str | None,
+    api_key_plain: str,
+) -> tuple[str, str]:
+    import base64
+
+    conv = get_or_create_conversation(db, user_id, conversation_id)
+    rows = (
+        db.query(Message)
+        .filter(Message.conversation_id == conv.id)
+        .order_by(Message.created_at.asc())
+        .all()
+    )
+    lc_hist = db_messages_to_lc(rows)
+
+    caption = (user_caption or "").strip()
+    if not caption:
+        caption = "Describe this food and estimate nutrition (calories and macros)."
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    media = media_type.strip() if media_type else "application/octet-stream"
+    content: list[str | dict] = [
+        {"type": "text", "text": caption},
+        {"type": "image_url", "image_url": {"url": f"data:{media};base64,{b64}"}},
+    ]
+    lc_hist.append(HumanMessage(content=content))
+    reply, _merged = invoke_graph_with_messages(api_key_plain, lc_hist)
+
+    db.add(
+        Message(
+            conversation_id=conv.id,
+            role="user",
+            content=caption,
+            has_image=True,
+        )
+    )
+    db.add(
+        Message(
+            conversation_id=conv.id,
+            role="assistant",
+            content=reply,
+            has_image=False,
+        )
+    )
+    if conv.title == "New chat":
+        conv.title = caption[:80] + ("…" if len(caption) > 80 else "")
+    conv.updated_at = datetime.utcnow()
+    db.commit()
+    return reply, conv.id
+
+
+def delete_conversation_for_user(db: Session, user_id: str, conversation_id: str) -> None:
+    conv = (
+        db.query(Conversation)
+        .filter(Conversation.id == conversation_id.strip(), Conversation.user_id == user_id)
+        .first()
+    )
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    db.delete(conv)
+    db.commit()

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,49 @@
+"""SQLAlchemy engine and session. Defaults to SQLite for local dev; use PostgreSQL on Railway."""
+
+from __future__ import annotations
+
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+def _database_url() -> str:
+    return os.environ.get("DATABASE_URL", "sqlite:///./diet_ai.db").strip()
+
+
+def _make_engine(url: str):
+    if url.startswith("sqlite"):
+        connect_args = {"check_same_thread": False}
+        if ":memory:" in url:
+            return create_engine(
+                url,
+                connect_args=connect_args,
+                poolclass=StaticPool,
+            )
+        return create_engine(url, connect_args=connect_args)
+    return create_engine(url, pool_pre_ping=True)
+
+
+DATABASE_URL = _database_url()
+engine = _make_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def init_db() -> None:
+    import models  # noqa: F401 — register models on Base.metadata
+
+    Base.metadata.create_all(bind=engine)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,28 +1,45 @@
-"""FastAPI backend: health, text chat, image chat."""
+"""FastAPI backend: health, auth, persisted chat, image chat, analytics."""
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
+from datetime import date, datetime, timedelta
 from typing import Any
 
 from fastapi import Depends, FastAPI, File, Form, Header, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from sqlalchemy import func
+from sqlalchemy.orm import Session
 
+from auth_tokens import create_access_token, decode_access_token, hash_password, verify_password
+from conversation_store import delete_conversation_for_user, run_persisted_image_chat, run_persisted_text_chat
 from crypto_util import decrypt_cryptojs_openssl
+from database import get_db, init_db
+from models import Conversation, Message, NutritionLog, User
 from nutrition_graph import reset_conversation, run_nutrition_chat, run_nutrition_image_chat
 
 
 class Settings(BaseSettings):
     app_password: str
     encryption_secret: str
+    jwt_secret: str = "dev-change-me-in-production-use-a-long-random-string"
+    jwt_expiry_hours: int = 168
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 
 settings = Settings()
 
-app = FastAPI(title="Diet Nutrition AI API", version="1.0.0")
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    init_db()
+    yield
+
+
+app = FastAPI(title="Diet Nutrition AI API", version="1.0.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
@@ -44,11 +61,23 @@ class ResetBody(BaseModel):
     conversation_id: str
 
 
-def verify_app_password(x_app_password: str | None = Header(None, alias="X-App-Password")) -> None:
-    if x_app_password is None:
-        raise HTTPException(status_code=403, detail="Missing X-App-Password header")
-    if x_app_password != settings.app_password:
-        raise HTTPException(status_code=403, detail="Invalid app password")
+class RegisterBody(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=128)
+
+
+class LoginBody(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class NutritionLogBody(BaseModel):
+    logged_on: date
+    calories: int | None = None
+    protein_g: float | None = None
+    carbs_g: float | None = None
+    fat_g: float | None = None
+    notes: str | None = Field(default=None, max_length=1024)
 
 
 def decrypt_user_key(enc: str) -> str:
@@ -58,7 +87,49 @@ def decrypt_user_key(enc: str) -> str:
         raise HTTPException(status_code=400, detail=f"Could not decrypt API key: {exc}") from exc
 
 
-DependsPassword = Depends(verify_app_password)
+def verify_app_password_header(x_app_password: str | None = Header(None, alias="X-App-Password")) -> None:
+    if x_app_password is None:
+        raise HTTPException(status_code=403, detail="Missing X-App-Password header")
+    if x_app_password != settings.app_password:
+        raise HTTPException(status_code=403, detail="Invalid app password")
+
+
+def optional_bearer_user(
+    authorization: str | None = Header(None),
+    db: Session = Depends(get_db),
+) -> User | None:
+    if not authorization or not authorization.startswith("Bearer "):
+        return None
+    token = authorization[7:].strip()
+    if not token:
+        return None
+    try:
+        user_id = decode_access_token(token, settings.jwt_secret)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid or expired token") from None
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user
+
+
+def verify_app_or_user(
+    x_app_password: str | None = Header(None, alias="X-App-Password"),
+    user: User | None = Depends(optional_bearer_user),
+) -> User | None:
+    if user is not None:
+        return user
+    verify_app_password_header(x_app_password)
+    return None
+
+
+DependsAppOrUser = Depends(verify_app_or_user)
+
+
+def require_user(user: User | None = Depends(optional_bearer_user)) -> User:
+    if user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user
 
 
 @app.get("/health")
@@ -66,43 +137,241 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+@app.post("/api/auth/register")
+async def api_register(
+    body: RegisterBody,
+    _: None = Depends(verify_app_password_header),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    existing = db.query(User).filter(User.email == body.email.lower().strip()).first()
+    if existing:
+        raise HTTPException(status_code=409, detail="Email already registered")
+    user = User(
+        email=body.email.lower().strip(),
+        hashed_password=hash_password(body.password),
+    )
+    db.add(user)
+    db.commit()
+    return {"ok": True, "email": user.email}
+
+
+@app.post("/api/auth/login")
+async def api_login(
+    body: LoginBody,
+    _: None = Depends(verify_app_password_header),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    user = db.query(User).filter(User.email == body.email.lower().strip()).first()
+    if not user or not verify_password(body.password, user.hashed_password):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+    token = create_access_token(
+        subject_user_id=user.id,
+        secret=settings.jwt_secret,
+        expires_hours=settings.jwt_expiry_hours,
+    )
+    return {"access_token": token, "token_type": "bearer", "user_id": user.id, "email": user.email}
+
+
+@app.get("/api/auth/me")
+async def api_me(user: User = Depends(require_user)) -> dict[str, str]:
+    return {"id": user.id, "email": user.email}
+
+
+@app.get("/api/conversations")
+async def list_conversations(
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+) -> list[dict[str, Any]]:
+    rows = (
+        db.query(Conversation)
+        .filter(Conversation.user_id == user.id)
+        .order_by(Conversation.updated_at.desc())
+        .all()
+    )
+    return [
+        {
+            "id": r.id,
+            "title": r.title,
+            "created_at": r.created_at.isoformat() + "Z",
+            "updated_at": r.updated_at.isoformat() + "Z",
+        }
+        for r in rows
+    ]
+
+
+@app.get("/api/conversations/{conversation_id}/messages")
+async def get_conversation_messages(
+    conversation_id: str,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+) -> dict[str, Any]:
+    conv = (
+        db.query(Conversation)
+        .filter(Conversation.id == conversation_id, Conversation.user_id == user.id)
+        .first()
+    )
+    if not conv:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    msgs = (
+        db.query(Message)
+        .filter(Message.conversation_id == conv.id)
+        .order_by(Message.created_at.asc())
+        .all()
+    )
+    return {
+        "conversation_id": conv.id,
+        "messages": [
+            {
+                "role": m.role,
+                "content": m.content,
+                "has_image": m.has_image,
+                "created_at": m.created_at.isoformat() + "Z",
+            }
+            for m in msgs
+        ],
+    }
+
+
+@app.delete("/api/conversations/{conversation_id}")
+async def api_delete_conversation(
+    conversation_id: str,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+) -> dict[str, bool]:
+    delete_conversation_for_user(db, user.id, conversation_id)
+    return {"ok": True}
+
+
+@app.post("/api/nutrition/logs")
+async def create_nutrition_log(
+    body: NutritionLogBody,
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+) -> dict[str, str]:
+    log = NutritionLog(
+        user_id=user.id,
+        logged_on=body.logged_on,
+        calories=body.calories,
+        protein_g=body.protein_g,
+        carbs_g=body.carbs_g,
+        fat_g=body.fat_g,
+        notes=body.notes,
+    )
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return {"id": log.id}
+
+
+@app.get("/api/analytics/activity")
+async def analytics_activity(
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+    days: int = 14,
+) -> dict[str, Any]:
+    days = max(1, min(days, 90))
+    start = datetime.utcnow().date() - timedelta(days=days - 1)
+    q = (
+        db.query(func.date(Message.created_at).label("d"), func.count(Message.id))
+        .join(Conversation, Message.conversation_id == Conversation.id)
+        .filter(
+            Conversation.user_id == user.id,
+            Message.role == "user",
+            func.date(Message.created_at) >= start,
+        )
+        .group_by(func.date(Message.created_at))
+        .order_by(func.date(Message.created_at))
+    )
+    bars = [{"date": str(row[0]), "user_messages": int(row[1])} for row in q.all()]
+    return {"days": days, "bars": bars}
+
+
+@app.get("/api/analytics/nutrition")
+async def analytics_nutrition(
+    user: User = Depends(require_user),
+    db: Session = Depends(get_db),
+    days: int = 14,
+) -> dict[str, Any]:
+    days = max(1, min(days, 90))
+    start = datetime.utcnow().date() - timedelta(days=days - 1)
+    q = (
+        db.query(NutritionLog.logged_on, func.sum(NutritionLog.calories))
+        .filter(NutritionLog.user_id == user.id, NutritionLog.logged_on >= start)
+        .group_by(NutritionLog.logged_on)
+        .order_by(NutritionLog.logged_on)
+    )
+    bars = [{"date": str(row[0]), "calories": int(row[1] or 0)} for row in q.all()]
+    return {"days": days, "bars": bars}
+
+
 @app.post("/api/chat")
-async def api_chat(body: ChatBody, _: None = DependsPassword) -> dict[str, Any]:
+async def api_chat(
+    body: ChatBody,
+    db: Session = Depends(get_db),
+    user: User | None = DependsAppOrUser,
+) -> dict[str, Any]:
     api_key_plain = decrypt_user_key(body.encrypted_api_key)
+    if user:
+        reply, conv_id = run_persisted_text_chat(
+            db,
+            user.id,
+            body.conversation_id,
+            body.message,
+            api_key_plain,
+        )
+        return {"reply": reply, "conversation_id": conv_id}
     reply, conv_id = run_nutrition_chat(api_key_plain, body.message, body.conversation_id)
     return {"reply": reply, "conversation_id": conv_id}
 
 
 @app.post("/api/chat/image")
 async def api_chat_image(
-    _: None = DependsPassword,
     encrypted_api_key: str = Form(...),
     conversation_id: str = Form(""),
     message: str = Form(""),
     image: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    user: User | None = DependsAppOrUser,
 ) -> dict[str, Any]:
     api_key_plain = decrypt_user_key(encrypted_api_key)
     raw = await image.read()
     if not raw:
         raise HTTPException(status_code=400, detail="Empty image upload")
     media = image.content_type or "application/octet-stream"
-    cid = conversation_id.strip() if conversation_id else None
+    cid_in = conversation_id.strip() if conversation_id else None
+    if user:
+        reply, conv_id = run_persisted_image_chat(
+            db,
+            user.id,
+            cid_in,
+            media,
+            raw,
+            message or None,
+            api_key_plain,
+        )
+        return {"reply": reply, "conversation_id": conv_id}
     reply, conv_id = run_nutrition_image_chat(
         api_key_plain,
         media,
         raw,
         message or None,
-        cid,
+        cid_in,
     )
     return {"reply": reply, "conversation_id": conv_id}
 
 
 @app.post("/api/chat/reset")
-async def api_chat_reset(body: ResetBody, _: None = DependsPassword) -> dict[str, Any]:
+async def api_chat_reset(
+    body: ResetBody,
+    db: Session = Depends(get_db),
+    user: User | None = DependsAppOrUser,
+) -> dict[str, Any]:
     _ = decrypt_user_key(body.encrypted_api_key)
     cid = body.conversation_id.strip()
     if not cid:
         raise HTTPException(status_code=400, detail="conversation_id required")
+    if user:
+        delete_conversation_for_user(db, user.id, cid)
+        return {"ok": True, "conversation_id": cid}
     reset_conversation(cid)
     return {"ok": True, "conversation_id": cid}
-

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,70 @@
+"""ORM models: users, conversations, messages, nutrition logs."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, Date, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+from database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    email = Column(String(320), unique=True, nullable=False, index=True)
+    hashed_password = Column(String(255), nullable=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    conversations = relationship("Conversation", back_populates="user", cascade="all, delete-orphan")
+    nutrition_logs = relationship("NutritionLog", back_populates="user", cascade="all, delete-orphan")
+
+
+class Conversation(Base):
+    __tablename__ = "conversations"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String(36), ForeignKey("users.id"), nullable=False, index=True)
+    title = Column(String(512), nullable=False, default="New chat")
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="conversations")
+    messages = relationship(
+        "Message",
+        back_populates="conversation",
+        cascade="all, delete-orphan",
+        order_by="Message.created_at",
+    )
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    conversation_id = Column(String(36), ForeignKey("conversations.id"), nullable=False, index=True)
+    role = Column(String(16), nullable=False)
+    content = Column(Text, nullable=False)
+    has_image = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    conversation = relationship("Conversation", back_populates="messages")
+
+
+class NutritionLog(Base):
+    __tablename__ = "nutrition_logs"
+
+    id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    user_id = Column(String(36), ForeignKey("users.id"), nullable=False, index=True)
+    logged_on = Column(Date, nullable=False)
+    calories = Column(Integer, nullable=True)
+    protein_g = Column(Float, nullable=True)
+    carbs_g = Column(Float, nullable=True)
+    fat_g = Column(Float, nullable=True)
+    notes = Column(String(1024), nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="nutrition_logs")

--- a/backend/nutrition_graph.py
+++ b/backend/nutrition_graph.py
@@ -55,6 +55,18 @@ def _assistant_text_from_result(out: dict) -> str:
     return body if isinstance(body, str) else str(body)
 
 
+def invoke_graph_with_messages(
+    decrypted_api_key: str,
+    messages: list[BaseMessage],
+) -> tuple[str, list[BaseMessage]]:
+    """Run the compiled graph on a full message list (must include the latest user turn)."""
+    graph = get_graph()
+    cfg: RunnableConfig = {"configurable": {"anthropic_api_key": decrypted_api_key}}
+    out = graph.invoke({"messages": messages}, cfg)
+    merged = list(out["messages"])
+    return _assistant_text_from_result(out), merged
+
+
 def _resolve_conversation_id(conversation_id: str | None) -> str:
     cid = conversation_id.strip() if conversation_id else ""
     return cid or str(uuid.uuid4())
@@ -65,15 +77,12 @@ def run_nutrition_chat(
     user_message: str,
     conversation_id: str | None,
 ) -> tuple[str, str]:
-    graph = get_graph()
     cid = _resolve_conversation_id(conversation_id)
     hist = _conversation_histories.setdefault(cid, [])
     hist.append(HumanMessage(content=user_message))
-    cfg: RunnableConfig = {"configurable": {"anthropic_api_key": decrypted_api_key}}
-    out = graph.invoke({"messages": hist}, cfg)
-    merged = list(out["messages"])
+    reply, merged = invoke_graph_with_messages(decrypted_api_key, hist)
     _conversation_histories[cid] = merged
-    return _assistant_text_from_result(out), cid
+    return reply, cid
 
 
 def run_nutrition_image_chat(
@@ -92,15 +101,12 @@ def run_nutrition_image_chat(
         {"type": "text", "text": caption},
         {"type": "image_url", "image_url": {"url": f"data:{media};base64,{b64}"}},
     ]
-    graph = get_graph()
     cid = _resolve_conversation_id(conversation_id)
     hist = _conversation_histories.setdefault(cid, [])
     hist.append(HumanMessage(content=content))
-    cfg: RunnableConfig = {"configurable": {"anthropic_api_key": decrypted_api_key}}
-    out = graph.invoke({"messages": hist}, cfg)
-    merged = list(out["messages"])
+    reply, merged = invoke_graph_with_messages(decrypted_api_key, hist)
     _conversation_histories[cid] = merged
-    return _assistant_text_from_result(out), cid
+    return reply, cid
 
 
 def reset_conversation(conversation_id: str) -> None:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,11 @@ uvicorn[standard]==0.27.1
 python-multipart==0.0.9
 pycryptodome==3.20.0
 pydantic-settings==2.1.0
+sqlalchemy>=2.0.0
+psycopg2-binary>=2.9.9
+bcrypt>=4.0.0
+python-jose[cryptography]>=3.3.0
+email-validator>=2.1.0
 langchain-core>=0.3.5
 langchain-anthropic>=0.3.0
 langgraph>=0.2.55

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,3 +6,5 @@ import os
 
 os.environ.setdefault("ENCRYPTION_SECRET", "test-shared-secret-for-pytest-only!!")
 os.environ.setdefault("APP_PASSWORD", "test-app-password")
+os.environ.setdefault("JWT_SECRET", "test-jwt-secret-min-32-chars-for-pytest!!")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,0 +1,73 @@
+"""Auth and persisted chat (SQLite in-memory)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage
+
+from crypto_util import encrypt_cryptojs_openssl
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    def fake_invoke(self, messages, *args, **kwargs):  # noqa: ANN001
+        return AIMessage(content="mock reply")
+
+    monkeypatch.setattr("langchain_anthropic.ChatAnthropic.invoke", fake_invoke)
+
+    from database import init_db
+
+    init_db()
+
+    from main import app
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def enc() -> str:
+    return encrypt_cryptojs_openssl("sk-test", "test-shared-secret-for-pytest-only!!")
+
+
+def test_register_login_persisted_chat(client: TestClient, enc: str) -> None:
+    h = {"X-App-Password": "test-app-password"}
+    r = client.post(
+        "/api/auth/register",
+        json={"email": "u1@example.com", "password": "password-one"},
+        headers=h,
+    )
+    assert r.status_code == 200
+
+    r2 = client.post(
+        "/api/auth/login",
+        json={"email": "u1@example.com", "password": "password-one"},
+        headers=h,
+    )
+    assert r2.status_code == 200
+    token = r2.json()["access_token"]
+
+    auth = {**h, "Authorization": f"Bearer {token}"}
+    c1 = client.post(
+        "/api/chat",
+        json={"encrypted_api_key": enc, "message": "hello db"},
+        headers=auth,
+    )
+    assert c1.status_code == 200
+    conv_id = c1.json()["conversation_id"]
+
+    c2 = client.post(
+        "/api/chat",
+        json={"encrypted_api_key": enc, "message": "second turn", "conversation_id": conv_id},
+        headers=auth,
+    )
+    assert c2.status_code == 200
+    assert c2.json()["conversation_id"] == conv_id
+
+    lst = client.get("/api/conversations", headers=auth)
+    assert lst.status_code == 200
+    assert len(lst.json()) >= 1
+
+    msgs = client.get(f"/api/conversations/{conv_id}/messages", headers=auth)
+    assert msgs.status_code == 200
+    assert len(msgs.json()["messages"]) == 4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: diet
+      POSTGRES_PASSWORD: diet
+      POSTGRES_DB: diet_ai
+    ports:
+      - "5432:5432"
+    volumes:
+      - diet_ai_pg:/var/lib/postgresql/data
+
+volumes:
+  diet_ai_pg:

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -8,12 +8,18 @@ import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  fetchConversationMessages,
+  listConversations,
+  type ConversationSummary,
+} from "@/lib/authApi";
+import {
   getApiBaseUrl,
   resetConversation as resetRemote,
   sendChatImage,
   sendChatMessage,
 } from "@/lib/chatApi";
 import { getStoredEncryptedApiKey } from "@/lib/encryptedApiKey";
+import { getStoredAccessToken, setStoredAccessToken } from "@/lib/authToken";
 
 type ChatMessage = {
   id: string;
@@ -42,6 +48,8 @@ const assistantMarkdownClass =
 export default function ChatPage() {
   const [mounted, setMounted] = useState(false);
   const [encryptedKey, setEncryptedKey] = useState<string | null>(null);
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
@@ -49,6 +57,7 @@ export default function ChatPage() {
     null
   );
   const [loading, setLoading] = useState(false);
+  const [listLoading, setListLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const endRef = useRef<HTMLDivElement | null>(null);
@@ -58,10 +67,26 @@ export default function ChatPage() {
   messagesRef.current = messages;
   pendingRef.current = pendingImage;
 
+  const refreshConversations = useCallback(async () => {
+    if (!getStoredAccessToken()) return;
+    try {
+      const list = await listConversations();
+      setConversations(list);
+    } catch {
+      /* ignore list errors in sidebar */
+    }
+  }, []);
+
   useEffect(() => {
     setMounted(true);
     setEncryptedKey(getStoredEncryptedApiKey()?.trim() ?? null);
+    setLoggedIn(Boolean(getStoredAccessToken()));
   }, []);
+
+  useEffect(() => {
+    if (!mounted || !encryptedKey?.trim() || !loggedIn) return;
+    void refreshConversations();
+  }, [mounted, encryptedKey, loggedIn, refreshConversations]);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -77,6 +102,47 @@ export default function ChatPage() {
   const appendMessage = useCallback((msg: Omit<ChatMessage, "id">) => {
     setMessages((prev) => [...prev, { ...msg, id: crypto.randomUUID() }]);
   }, []);
+
+  function startNewChat() {
+    revokeMessageImages(messages);
+    setMessages([]);
+    setConversationId(null);
+  }
+
+  function logout() {
+    revokeMessageImages(messages);
+    if (pendingImage?.previewUrl) URL.revokeObjectURL(pendingImage.previewUrl);
+    setPendingImage(null);
+    setStoredAccessToken(null);
+    setLoggedIn(false);
+    setConversations([]);
+    setMessages([]);
+    setConversationId(null);
+  }
+
+  async function openConversation(id: string) {
+    setListLoading(true);
+    setError(null);
+    try {
+      const rows = await fetchConversationMessages(id);
+      revokeMessageImages(messages);
+      setConversationId(id);
+      setMessages(
+        rows.map((r) => ({
+          id: crypto.randomUUID(),
+          role: (r.role === "assistant" ? "assistant" : "user") as "user" | "assistant",
+          content:
+            r.role === "user" && r.has_image && !r.content.includes("📷")
+              ? `${r.content}\n📷 (saved photo)`
+              : r.content,
+        }))
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not load conversation.");
+    } finally {
+      setListLoading(false);
+    }
+  }
 
   async function submitTextMessage() {
     setError(null);
@@ -98,6 +164,7 @@ export default function ChatPage() {
       });
       appendMessage({ role: "assistant", content: data.reply });
       setConversationId(data.conversation_id);
+      await refreshConversations();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Request failed.");
     } finally {
@@ -133,6 +200,7 @@ export default function ChatPage() {
       });
       appendMessage({ role: "assistant", content: data.reply });
       setConversationId(data.conversation_id);
+      await refreshConversations();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Request failed.");
     } finally {
@@ -184,6 +252,7 @@ export default function ChatPage() {
       await resetRemote(key, conversationId);
       setMessages([]);
       setConversationId(null);
+      await refreshConversations();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Reset failed.");
     } finally {
@@ -192,8 +261,7 @@ export default function ChatPage() {
   }
 
   const hasKey = Boolean(encryptedKey);
-  const canSend =
-    !loading && (Boolean(draft.trim()) || Boolean(pendingImage));
+  const canSend = !loading && (Boolean(draft.trim()) || Boolean(pendingImage));
 
   return (
     <main className="flex min-h-dvh flex-col bg-background">
@@ -208,9 +276,28 @@ export default function ChatPage() {
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
+          {loggedIn ? (
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/dashboard">Dashboard</Link>
+            </Button>
+          ) : (
+            <>
+              <Button variant="outline" size="sm" asChild>
+                <Link href="/login">Sign in</Link>
+              </Button>
+              <Button variant="ghost" size="sm" asChild>
+                <Link href="/register">Register</Link>
+              </Button>
+            </>
+          )}
           <Button type="button" variant="outline" size="sm" disabled={loading} onClick={() => handleReset()}>
             Reset thread
           </Button>
+          {loggedIn ? (
+            <Button type="button" variant="ghost" size="sm" onClick={logout}>
+              Log out
+            </Button>
+          ) : null}
           <Button variant="ghost" size="sm" asChild>
             <Link href="/setup">API key</Link>
           </Button>
@@ -232,122 +319,161 @@ export default function ChatPage() {
             </Button>
           </div>
         ) : (
-          <>
-            <section className="flex-1 overflow-y-auto px-4 py-4" aria-label="Conversation">
-              {messages.length === 0 ? (
-                <p className="mx-auto max-w-xl text-center text-sm text-muted-foreground">
-                  Ask about nutrition or attach a photo of food for analysis — thread stays until you reset or refresh.
-                </p>
-              ) : (
-                <ul className="mx-auto flex max-w-xl flex-col gap-3">
-                  {messages.map((m) => (
-                    <li key={m.id} className={m.role === "user" ? "flex justify-end" : "flex justify-start"}>
-                      <div
-                        className={
-                          m.role === "user"
-                            ? "max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-primary px-3 py-2 text-primary-foreground"
-                            : "max-w-[85%] rounded-2xl rounded-bl-md bg-muted px-3 py-2 text-foreground"
-                        }
-                      >
-                        {m.role === "user" && m.imagePreviewUrl ? (
-                          <div className="mb-2 overflow-hidden rounded-lg">
-                            {/* Blob URLs — next/image optimizer not applicable */}
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img alt="" src={m.imagePreviewUrl} className="max-h-56 w-full object-cover" />
-                          </div>
-                        ) : null}
-                        {m.role === "assistant" ? (
-                          <div className={assistantMarkdownClass}>
-                            <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.content}</ReactMarkdown>
-                          </div>
-                        ) : (
-                          m.content
-                        )}
-                      </div>
-                    </li>
-                  ))}
-                  <div ref={endRef} />
-                </ul>
-              )}
-              {conversationId ? (
-                <p className="mt-6 text-center text-[11px] text-muted-foreground">
-                  Conversation <code className="rounded bg-muted px-1">{conversationId.slice(0, 8)}…</code>
-                </p>
-              ) : null}
-            </section>
-
-            {error ? (
-              <div className="border-t border-border bg-destructive/10 px-4 py-2 text-center text-sm text-destructive">
-                {error}
-              </div>
-            ) : null}
-
-            <form
-              className="border-t border-border bg-card p-4"
-              onSubmit={(e) => {
-                e.preventDefault();
-                void submitOutgoing();
-              }}
-            >
-              <input
-                ref={fileInputRef}
-                type="file"
-                className="sr-only"
-                accept="image/*"
-                aria-label="Choose food photo"
-                onChange={onPickFile}
-              />
-              <div className="mx-auto flex max-w-xl flex-col gap-2">
-                {pendingImage ? (
-                  <div className="relative flex items-start gap-3 rounded-lg border border-border bg-muted/30 p-2">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      alt=""
-                      src={pendingImage.previewUrl}
-                      className="h-20 w-20 shrink-0 rounded-md border border-border object-cover"
-                    />
-                    <div className="min-w-0 flex-1 text-xs text-muted-foreground">
-                      <p className="truncate font-medium text-foreground">{pendingImage.file.name}</p>
-                      <p>Uses vision endpoint. Add an optional caption below, then send.</p>
-                    </div>
-                    <Button type="button" variant="outline" size="sm" className="shrink-0" onClick={clearPendingImage}>
-                      Remove
-                    </Button>
-                  </div>
-                ) : null}
-                <Textarea
-                  value={draft}
-                  onChange={(e) => setDraft(e.target.value)}
-                  placeholder={
-                    pendingImage ? "Optional caption (e.g. rough portion size)" : "Type a message…"
-                  }
-                  rows={3}
-                  disabled={loading}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      if (canSend) void submitOutgoing();
-                    }
-                  }}
-                  className="resize-none"
-                  aria-label="Message"
-                />
-                <div className="flex flex-wrap justify-between gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    disabled={loading}
-                    onClick={() => fileInputRef.current?.click()}
-                  >
-                    Photo
-                  </Button>
-                  <Button type="submit" disabled={!canSend}>
-                    {loading ? "Sending…" : pendingImage ? "Send photo" : "Send"}
+          <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+            {loggedIn ? (
+              <aside
+                className="flex max-h-48 shrink-0 flex-col border-b border-border md:max-h-none md:w-56 md:border-b-0 md:border-r"
+                aria-label="Saved conversations"
+              >
+                <div className="flex flex-wrap gap-2 border-b border-border p-2 md:border-b">
+                  <Button type="button" size="sm" variant="secondary" disabled={listLoading} onClick={startNewChat}>
+                    New chat
                   </Button>
                 </div>
-              </div>
-            </form>
-          </>
+                <ul className="min-h-0 flex-1 space-y-1 overflow-y-auto p-2">
+                  {conversations.map((c) => (
+                    <li key={c.id}>
+                      <button
+                        type="button"
+                        disabled={listLoading}
+                        className={
+                          "w-full truncate rounded-md px-2 py-1.5 text-left text-xs transition-colors " +
+                          (conversationId === c.id
+                            ? "bg-muted font-medium text-foreground"
+                            : "text-muted-foreground hover:bg-muted/60")
+                        }
+                        onClick={() => void openConversation(c.id)}
+                      >
+                        {c.title || c.id.slice(0, 8)}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </aside>
+            ) : null}
+
+            <div className="flex min-w-0 min-h-0 flex-1 flex-col">
+              <section className="flex-1 overflow-y-auto px-4 py-4" aria-label="Conversation">
+                {loggedIn ? (
+                  <p className="mx-auto mb-3 max-w-xl text-center text-[11px] text-muted-foreground">
+                    You are signed in — threads are saved and appear in the sidebar.
+                  </p>
+                ) : null}
+                {messages.length === 0 ? (
+                  <p className="mx-auto max-w-xl text-center text-sm text-muted-foreground">
+                    Ask about nutrition or attach a photo of food for analysis.
+                    {!loggedIn ? " Without an account, the thread only lives in the server process until reset or restart." : ""}
+                  </p>
+                ) : (
+                  <ul className="mx-auto flex max-w-xl flex-col gap-3">
+                    {messages.map((m) => (
+                      <li key={m.id} className={m.role === "user" ? "flex justify-end" : "flex justify-start"}>
+                        <div
+                          className={
+                            m.role === "user"
+                              ? "max-w-[85%] whitespace-pre-wrap rounded-2xl rounded-br-md bg-primary px-3 py-2 text-primary-foreground"
+                              : "max-w-[85%] rounded-2xl rounded-bl-md bg-muted px-3 py-2 text-foreground"
+                          }
+                        >
+                          {m.role === "user" && m.imagePreviewUrl ? (
+                            <div className="mb-2 overflow-hidden rounded-lg">
+                              {/* eslint-disable-next-line @next/next/no-img-element */}
+                              <img alt="" src={m.imagePreviewUrl} className="max-h-56 w-full object-cover" />
+                            </div>
+                          ) : null}
+                          {m.role === "assistant" ? (
+                            <div className={assistantMarkdownClass}>
+                              <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.content}</ReactMarkdown>
+                            </div>
+                          ) : (
+                            m.content
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                    <div ref={endRef} />
+                  </ul>
+                )}
+                {conversationId ? (
+                  <p className="mt-6 text-center text-[11px] text-muted-foreground">
+                    Conversation <code className="rounded bg-muted px-1">{conversationId.slice(0, 8)}…</code>
+                  </p>
+                ) : null}
+              </section>
+
+              {error ? (
+                <div className="border-t border-border bg-destructive/10 px-4 py-2 text-center text-sm text-destructive">
+                  {error}
+                </div>
+              ) : null}
+
+              <form
+                className="border-t border-border bg-card p-4"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  void submitOutgoing();
+                }}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  className="sr-only"
+                  accept="image/*"
+                  aria-label="Choose food photo"
+                  onChange={onPickFile}
+                />
+                <div className="mx-auto flex max-w-xl flex-col gap-2">
+                  {pendingImage ? (
+                    <div className="relative flex items-start gap-3 rounded-lg border border-border bg-muted/30 p-2">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        alt=""
+                        src={pendingImage.previewUrl}
+                        className="h-20 w-20 shrink-0 rounded-md border border-border object-cover"
+                      />
+                      <div className="min-w-0 flex-1 text-xs text-muted-foreground">
+                        <p className="truncate font-medium text-foreground">{pendingImage.file.name}</p>
+                        <p>Uses vision endpoint. Add an optional caption below, then send.</p>
+                      </div>
+                      <Button type="button" variant="outline" size="sm" className="shrink-0" onClick={clearPendingImage}>
+                        Remove
+                      </Button>
+                    </div>
+                  ) : null}
+                  <Textarea
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    placeholder={
+                      pendingImage ? "Optional caption (e.g. rough portion size)" : "Type a message…"
+                    }
+                    rows={3}
+                    disabled={loading}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" && !e.shiftKey) {
+                        e.preventDefault();
+                        if (canSend) void submitOutgoing();
+                      }
+                    }}
+                    className="resize-none"
+                    aria-label="Message"
+                  />
+                  <div className="flex flex-wrap justify-between gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={loading}
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      Photo
+                    </Button>
+                    <Button type="submit" disabled={!canSend}>
+                      {loading ? "Sending…" : pendingImage ? "Send photo" : "Send"}
+                    </Button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
         )}
       </div>
     </main>

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  createNutritionLog,
+  fetchActivityAnalytics,
+  fetchNutritionAnalytics,
+} from "@/lib/authApi";
+import { getStoredAccessToken } from "@/lib/authToken";
+
+export default function DashboardPage() {
+  const [mounted, setMounted] = useState(false);
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [activity, setActivity] = useState<{ date: string; user_messages: number }[]>([]);
+  const [nutrition, setNutrition] = useState<{ date: string; calories: number }[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [logDate, setLogDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [logCalories, setLogCalories] = useState("");
+  const [logNotes, setLogNotes] = useState("");
+
+  useEffect(() => {
+    setMounted(true);
+    setLoggedIn(Boolean(getStoredAccessToken()));
+  }, []);
+
+  useEffect(() => {
+    if (!loggedIn) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [a, n] = await Promise.all([fetchActivityAnalytics(14), fetchNutritionAnalytics(14)]);
+        if (!cancelled) {
+          setActivity(a.bars);
+          setNutrition(n.bars);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load analytics.");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loggedIn]);
+
+  async function submitLog(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const cal = logCalories.trim() ? Number(logCalories) : undefined;
+    if (logCalories.trim() && (Number.isNaN(cal) || cal! < 0)) {
+      setError("Calories must be a non-negative number.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await createNutritionLog({
+        logged_on: logDate,
+        calories: cal ?? null,
+        notes: logNotes.trim() || null,
+      });
+      const n = await fetchNutritionAnalytics(14);
+      setNutrition(n.bars);
+      setLogNotes("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not save log.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!mounted) {
+    return (
+      <main className="min-h-dvh flex items-center justify-center text-muted-foreground text-sm">Loading…</main>
+    );
+  }
+
+  if (!loggedIn) {
+    return (
+      <main className="min-h-dvh flex flex-col items-center justify-center gap-4 p-6 bg-background">
+        <p className="text-sm text-muted-foreground">Sign in to see your analytics.</p>
+        <Button asChild>
+          <Link href="/login">Sign in</Link>
+        </Button>
+        <Button variant="ghost" asChild>
+          <Link href="/">Home</Link>
+        </Button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-dvh bg-background">
+      <header className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-4 py-3">
+        <h1 className="text-lg font-semibold tracking-tight">Dashboard</h1>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/chat">Chat</Link>
+          </Button>
+          <Button variant="ghost" size="sm" asChild>
+            <Link href="/">Home</Link>
+          </Button>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-3xl space-y-8 p-4">
+        {error ? (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+
+        <section className="space-y-2">
+          <h2 className="text-sm font-medium">Chat activity</h2>
+          <p className="text-xs text-muted-foreground">Your messages per day (last 14 days).</p>
+          <div className="h-56 w-full rounded-lg border border-border bg-card p-2">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={activity} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis dataKey="date" tick={{ fontSize: 10 }} className="text-muted-foreground" />
+                <YAxis allowDecimals={false} tick={{ fontSize: 10 }} width={32} />
+                <Tooltip />
+                <Bar dataKey="user_messages" name="Messages" fill="#404040" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-sm font-medium">Logged calories</h2>
+          <p className="text-xs text-muted-foreground">Sum of manual nutrition entries by day.</p>
+          <div className="h-56 w-full rounded-lg border border-border bg-card p-2">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={nutrition} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis dataKey="date" tick={{ fontSize: 10 }} className="text-muted-foreground" />
+                <YAxis tick={{ fontSize: 10 }} width={40} />
+                <Tooltip />
+                <Bar dataKey="calories" name="Calories" fill="hsl(142 60% 40%)" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </section>
+
+        <section className="space-y-3 rounded-lg border border-border bg-card p-4">
+          <h2 className="text-sm font-medium">Add nutrition log</h2>
+          <form onSubmit={(e) => void submitLog(e)} className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+            <div className="space-y-1">
+              <label htmlFor="logDate" className="text-xs text-muted-foreground">
+                Date
+              </label>
+              <Input
+                id="logDate"
+                type="date"
+                value={logDate}
+                onChange={(e) => setLogDate(e.target.value)}
+                disabled={busy}
+              />
+            </div>
+            <div className="space-y-1">
+              <label htmlFor="cal" className="text-xs text-muted-foreground">
+                Calories (optional)
+              </label>
+              <Input
+                id="cal"
+                type="number"
+                min={0}
+                placeholder="e.g. 450"
+                value={logCalories}
+                onChange={(e) => setLogCalories(e.target.value)}
+                disabled={busy}
+                className="w-32"
+              />
+            </div>
+            <div className="min-w-[12rem] flex-1 space-y-1">
+              <label htmlFor="notes" className="text-xs text-muted-foreground">
+                Notes
+              </label>
+              <Input
+                id="notes"
+                value={logNotes}
+                onChange={(e) => setLogNotes(e.target.value)}
+                disabled={busy}
+                placeholder="Meal notes"
+              />
+            </div>
+            <Button type="submit" disabled={busy}>
+              Save
+            </Button>
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { loginAccount } from "@/lib/authApi";
+import { setStoredAccessToken } from "@/lib/authToken";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await loginAccount(email.trim(), password);
+      setStoredAccessToken(res.access_token);
+      router.push("/chat");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Login failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="min-h-dvh flex flex-col items-center justify-center gap-6 p-6 bg-background">
+      <div className="w-full max-w-sm space-y-4">
+        <div className="text-center space-y-1">
+          <h1 className="text-xl font-semibold tracking-tight">Sign in</h1>
+          <p className="text-sm text-muted-foreground">Use the same app password env as the API on every request.</p>
+        </div>
+        <form onSubmit={(e) => void onSubmit(e)} className="space-y-3 rounded-lg border border-border bg-card p-4">
+          <div className="space-y-1">
+            <label htmlFor="email" className="text-sm font-medium">
+              Email
+            </label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={busy}
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="password" className="text-sm font-medium">
+              Password
+            </label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+              disabled={busy}
+            />
+          </div>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          <Button type="submit" className="w-full" disabled={busy}>
+            {busy ? "Signing in…" : "Sign in"}
+          </Button>
+        </form>
+        <p className="text-center text-sm text-muted-foreground">
+          No account?{" "}
+          <Link href="/register" className="text-primary underline">
+            Register
+          </Link>
+          {" · "}
+          <Link href="/" className="underline">
+            Home
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -19,6 +19,15 @@ export default function Home() {
         <Button asChild variant="secondary">
           <Link href="/chat">Open chat</Link>
         </Button>
+        <Button asChild variant="outline">
+          <Link href="/register">Register</Link>
+        </Button>
+        <Button asChild variant="ghost">
+          <Link href="/login">Sign in</Link>
+        </Button>
+        <Button asChild variant="ghost">
+          <Link href="/dashboard">Dashboard</Link>
+        </Button>
       </div>
     </main>
   );

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { registerAccount } from "@/lib/authApi";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setBusy(true);
+    try {
+      await registerAccount(email.trim(), password);
+      router.push("/login");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Registration failed.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="min-h-dvh flex flex-col items-center justify-center gap-6 p-6 bg-background">
+      <div className="w-full max-w-sm space-y-4">
+        <div className="text-center space-y-1">
+          <h1 className="text-xl font-semibold tracking-tight">Create account</h1>
+          <p className="text-sm text-muted-foreground">Password at least 8 characters.</p>
+        </div>
+        <form onSubmit={(e) => void onSubmit(e)} className="space-y-3 rounded-lg border border-border bg-card p-4">
+          <div className="space-y-1">
+            <label htmlFor="email" className="text-sm font-medium">
+              Email
+            </label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={busy}
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="password" className="text-sm font-medium">
+              Password
+            </label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+              disabled={busy}
+            />
+          </div>
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          <Button type="submit" className="w-full" disabled={busy}>
+            {busy ? "Creating…" : "Register"}
+          </Button>
+        </form>
+        <p className="text-center text-sm text-muted-foreground">
+          Already have an account?{" "}
+          <Link href="/login" className="text-primary underline">
+            Sign in
+          </Link>
+          {" · "}
+          <Link href="/" className="underline">
+            Home
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/lib/authApi.ts
+++ b/frontend/lib/authApi.ts
@@ -1,0 +1,134 @@
+/**
+ * Registration, login, and analytics APIs (Bearer JWT where required).
+ */
+
+import { getApiBaseUrl, getAppPassword } from "./chatApi";
+import { getStoredAccessToken } from "./authToken";
+
+function requirePwdHeaders(): Record<string, string> {
+  const pwd = getAppPassword();
+  if (!pwd) {
+    throw new Error(
+      "NEXT_PUBLIC_APP_PASSWORD is not set. It must match the backend APP_PASSWORD (see frontend/.env.example)."
+    );
+  }
+  return { "X-App-Password": pwd };
+}
+
+function authBearerHeaders(): Record<string, string> {
+  const pwd = requirePwdHeaders();
+  const t = getStoredAccessToken();
+  if (!t) throw new Error("Not logged in.");
+  return { ...pwd, Authorization: `Bearer ${t}` };
+}
+
+async function parseErrorResponse(res: Response): Promise<string> {
+  try {
+    const raw = await res.text();
+    if (!raw) return res.statusText || `HTTP ${res.status}`;
+    const j = JSON.parse(raw) as { detail?: unknown };
+    const d = j.detail;
+    if (typeof d === "string") return d;
+    if (Array.isArray(d)) {
+      return d.map((item: { msg?: string }) => item?.msg ?? JSON.stringify(item)).join("; ");
+    }
+    if (d !== undefined) return typeof d === "string" ? d : JSON.stringify(d);
+    return raw;
+  } catch {
+    return res.statusText || `HTTP ${res.status}`;
+  }
+}
+
+export async function registerAccount(email: string, password: string): Promise<{ ok: boolean; email: string }> {
+  const url = `${getApiBaseUrl()}/api/auth/register`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...requirePwdHeaders() },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) throw new Error(await parseErrorResponse(res));
+  return (await res.json()) as { ok: boolean; email: string };
+}
+
+export async function loginAccount(
+  email: string,
+  password: string
+): Promise<{ access_token: string; email: string }> {
+  const url = `${getApiBaseUrl()}/api/auth/login`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...requirePwdHeaders() },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) throw new Error(await parseErrorResponse(res));
+  const data = (await res.json()) as { access_token: string; email: string };
+  return data;
+}
+
+export type ConversationSummary = {
+  id: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export async function listConversations(): Promise<ConversationSummary[]> {
+  const res = await fetch(`${getApiBaseUrl()}/api/conversations`, {
+    headers: authBearerHeaders(),
+  });
+  if (!res.ok) throw new Error(await parseErrorResponse(res));
+  return (await res.json()) as ConversationSummary[];
+}
+
+export type ServerMessage = {
+  role: string;
+  content: string;
+  has_image: boolean;
+  created_at: string;
+};
+
+export async function fetchConversationMessages(conversationId: string): Promise<ServerMessage[]> {
+  const res = await fetch(`${getApiBaseUrl()}/api/conversations/${conversationId}/messages`, {
+    headers: authBearerHeaders(),
+  });
+  if (!res.ok) throw new Error(await parseErrorResponse(res));
+  const data = (await res.json()) as { messages: ServerMessage[] };
+  return data.messages;
+}
+
+export type ActivityBar = { date: string; user_messages: number };
+export type NutritionBar = { date: string; calories: number };
+
+export async function fetchActivityAnalytics(days = 14): Promise<{ days: number; bars: ActivityBar[] }> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/api/analytics/activity?days=${encodeURIComponent(String(days))}`,
+    { headers: authBearerHeaders() }
+  );
+  if (!res.ok) throw new Error(await parseErrorResponse(res));
+  return (await res.json()) as { days: number; bars: ActivityBar[] };
+}
+
+export async function fetchNutritionAnalytics(days = 14): Promise<{ days: number; bars: NutritionBar[] }> {
+  const res = await fetch(
+    `${getApiBaseUrl()}/api/analytics/nutrition?days=${encodeURIComponent(String(days))}`,
+    { headers: authBearerHeaders() }
+  );
+  if (!res.ok) throw new Error(await parseErrorResponse(res));
+  return (await res.json()) as { days: number; bars: NutritionBar[] };
+}
+
+export async function createNutritionLog(entry: {
+  logged_on: string;
+  calories?: number | null;
+  protein_g?: number | null;
+  carbs_g?: number | null;
+  fat_g?: number | null;
+  notes?: string | null;
+}): Promise<void> {
+  const res = await fetch(`${getApiBaseUrl()}/api/nutrition/logs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authBearerHeaders() },
+    body: JSON.stringify(entry),
+  });
+  if (!res.ok) throw new Error(await parseErrorResponse(res));
+}

--- a/frontend/lib/authToken.ts
+++ b/frontend/lib/authToken.ts
@@ -1,0 +1,12 @@
+const AUTH_KEY = "diet_ai_access_token";
+
+export function getStoredAccessToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(AUTH_KEY)?.trim() || null;
+}
+
+export function setStoredAccessToken(token: string | null): void {
+  if (typeof window === "undefined") return;
+  if (token) localStorage.setItem(AUTH_KEY, token);
+  else localStorage.removeItem(AUTH_KEY);
+}

--- a/frontend/lib/chatApi.ts
+++ b/frontend/lib/chatApi.ts
@@ -2,6 +2,8 @@
  * Backend text chat, image upload, and reset.
  */
 
+import { getStoredAccessToken } from "./authToken";
+
 export function getApiBaseUrl(): string {
   const raw = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
   return raw.replace(/\/$/, "");
@@ -10,6 +12,19 @@ export function getApiBaseUrl(): string {
 export function getAppPassword(): string | undefined {
   const p = process.env.NEXT_PUBLIC_APP_PASSWORD?.trim();
   return p || undefined;
+}
+
+function appAuthHeaders(): Record<string, string> {
+  const pwd = getAppPassword();
+  if (!pwd) {
+    throw new Error(
+      "NEXT_PUBLIC_APP_PASSWORD is not set. It must match the backend APP_PASSWORD (see frontend/.env.example)."
+    );
+  }
+  const headers: Record<string, string> = { "X-App-Password": pwd };
+  const token = getStoredAccessToken();
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
 }
 
 function stringifyDetail(data: unknown): string {
@@ -43,18 +58,10 @@ async function parseErrorResponse(res: Response): Promise<string> {
 }
 
 async function postAppFormData<T>(path: string, formData: FormData): Promise<T> {
-  const pwd = getAppPassword();
-  if (!pwd) {
-    throw new Error(
-      "NEXT_PUBLIC_APP_PASSWORD is not set. It must match the backend APP_PASSWORD (see frontend/.env.example)."
-    );
-  }
   const url = `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
   const res = await fetch(url, {
     method: "POST",
-    headers: {
-      "X-App-Password": pwd,
-    },
+    headers: appAuthHeaders(),
     body: formData,
   });
   if (!res.ok) {
@@ -65,18 +72,12 @@ async function postAppFormData<T>(path: string, formData: FormData): Promise<T> 
 }
 
 async function postAppJson<T>(path: string, body: Record<string, unknown>): Promise<T> {
-  const pwd = getAppPassword();
-  if (!pwd) {
-    throw new Error(
-      "NEXT_PUBLIC_APP_PASSWORD is not set. It must match the backend APP_PASSWORD (see frontend/.env.example)."
-    );
-  }
   const url = `${getApiBaseUrl()}${path.startsWith("/") ? path : `/${path}`}`;
   const res = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-App-Password": pwd,
+      ...appAuthHeaders(),
     },
     body: JSON.stringify(body),
   });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^10.1.0",
+        "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0"
       },
@@ -1543,6 +1544,42 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1918,7 +1955,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -2145,6 +2187,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmmirror.com/@types/debug/-/debug-4.1.13.tgz",
@@ -2247,6 +2352,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmmirror.com/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/whatwg-mimetype": {
@@ -3796,6 +3907,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmmirror.com/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -3910,6 +4142,12 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -4255,6 +4493,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -4770,6 +5018,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -5469,6 +5723,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmmirror.com/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5544,6 +5808,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -8174,7 +8447,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmmirror.com/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -8202,6 +8474,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -8235,6 +8530,36 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/redent/-/redent-3.0.0.tgz",
@@ -8247,6 +8572,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -8370,6 +8710,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -9335,6 +9681,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
@@ -9838,6 +10190,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9870,6 +10231,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"
   },


### PR DESCRIPTION
## Summary
Implements **#35** (durable chat history) and **#36** (accounts + bar charts). See commit `4828fb5` for full details.

### Highlights
- SQLAlchemy + PostgreSQL (`DATABASE_URL`) or default SQLite
- JWT auth (`JWT_SECRET`), register/login, Bearer on chat for persistence
- Conversation list + messages APIs; analytics + nutrition logs
- Frontend: `/login`, `/register`, `/dashboard` (Recharts), chat sidebar when signed in
- `docker-compose.yml` for local Postgres; CI env for pytest

Closes #35
Closes #36